### PR TITLE
printManifestHandler: Do not crash on "file does not exist"

### DIFF
--- a/lepton/elf.go
+++ b/lepton/elf.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"debug/elf"
 	"os"
+	"github.com/go-errors/errors"
 )
 
 func lookupFile(path string) (string, error) {
@@ -70,12 +71,12 @@ func findLib(libDirs []string, path string) (string, error) {
 func _getSharedLibs(path string) ([]string, error) {
 	path, err := lookupFile(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.WrapPrefix(err, path, 0)
 	}
 
 	fd, err := elf.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, errors.WrapPrefix(err, path, 0)
 	}
 	defer fd.Close()
 
@@ -103,7 +104,7 @@ func _getSharedLibs(path string) ([]string, error) {
 		// append library
 		absLibpath, err := findLib(dt_runpath, libpath)
 		if err != nil {
-			return nil, err
+			return nil, errors.WrapPrefix(err, libpath, 0)
 		}
 		libs = append(libs, absLibpath)
 

--- a/ops.go
+++ b/ops.go
@@ -152,6 +152,7 @@ func printManifestHandler(cmd *cobra.Command, args []string) {
 	m, err := api.BuildManifest(c)
 	if err != nil {
 		fmt.Println(err)
+		return
 	}
 	fmt.Println(m.String())
 }


### PR DESCRIPTION
- printManifestHandler: Do not crash on "file does not exist"
- getSharedLibs: Better error reporting