### PR TITLE
Do hypervisor check first.

### DIFF
--- a/ops.go
+++ b/ops.go
@@ -61,6 +61,10 @@ func unWarpConfig(file string) *api.Config {
 }
 
 func runCommandHandler(cmd *cobra.Command, args []string) {
+	hypervisor := api.HypervisorInstance()
+	if hypervisor == nil {
+		panic(errors.New("No hypervisor found on $PATH"))
+	}
 
 	force, err := strconv.ParseBool(cmd.Flag("force").Value.String())
 	if err != nil {
@@ -119,10 +123,6 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 
 	fmt.Printf("booting %s ...\n", api.FinalImg)
 
-	hypervisor := api.HypervisorInstance()
-	if hypervisor == nil {
-		panic(errors.New("No hypervisor found on $PATH"))
-	}
 	InitDefaultRunConfigs(c, ports)
 	hypervisor.Start(&c.RunConfig)
 }
@@ -240,6 +240,10 @@ func mergeConfigs(pkgConfig *api.Config, usrConfig *api.Config) *api.Config {
 }
 
 func loadCommandHandler(cmd *cobra.Command, args []string) {
+	hypervisor := api.HypervisorInstance()
+	if hypervisor == nil {
+		panic(errors.New("No hypervisor found on $PATH"))
+	}
 
 	localpackage := api.DownloadPackage(args[0])
 	fmt.Printf("Extracting %s...\n", localpackage)
@@ -312,10 +316,6 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("booting %s ...\n", api.FinalImg)
-	hypervisor := api.HypervisorInstance()
-	if hypervisor == nil {
-		panic(errors.New("No hypervisor found on $PATH"))
-	}
 
 	InitDefaultRunConfigs(c, ports)
 	hypervisor.Start(&c.RunConfig)


### PR DESCRIPTION
Low hanging fruit. Don't do download and all of that stuff before checking for a supported hypervisor.

It doesn't seem worth it to DRY those two blocks of code until they do a bit more. Also, I am sure there is a plan for uniform error handling, so I don't want to just the gun and extract out the common error to something more DRY yet.