### PR TITLE
Refactor Qemu code for easy tranformation from run configuration.

### DIFF
--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -7,30 +7,107 @@ import (
 	"strings"
 )
 
+const qemuBaseCommand = "qemu-system-x86_64"
+
 type drive struct {
 	path   string
 	format string
+	iftype string
+	index  string
+}
+
+type device struct {
+	driver   string
+	mac      string
+	netdevid string
 }
 
 type netdev struct {
-	nettype string
-	id      string
-	ifname  string
-	mac     string
+	nettype    string
+	id         string
+	ifname     string
+	script     string
+	downscript string
+	hports     []portfwd
+}
+
+type portfwd struct {
+	port  int
+	proto string
+}
+
+type display struct {
+	disptype string
+}
+
+type serial struct {
+	serialtype string
 }
 
 type qemu struct {
-	cmd    *exec.Cmd
-	drives []drive
-	ifaces []netdev
+	cmd     *exec.Cmd
+	drives  []drive
+	devices []device
+	ifaces  []netdev
+	display display
+	serial  serial
 }
 
-func (q *qemu) addDrive(path string, format string) {
-
+func (d display) String() string {
+	return fmt.Sprintf("-display %s", d.disptype)
 }
 
-func (q *qemu) addNetworkDevice(n netdev) {
+func (s serial) String() string {
+	return fmt.Sprintf("-serial %s", s.serialtype)
+}
 
+func (d drive) String() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("-drive file=%s,format=%s", d.path, d.format))
+	if len(d.index) > 0 {
+		sb.WriteString(fmt.Sprintf(",index=%s", d.index))
+	}
+	if len(d.iftype) > 0 {
+		sb.WriteString(fmt.Sprintf(",if=%s", d.iftype))
+	}
+	return sb.String()
+}
+
+func (dv device) String() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("-device %s,netdev=%s", dv.driver, dv.netdevid))
+	if len(dv.mac) > 0 {
+		sb.WriteString(fmt.Sprintf(",mac=%s", dv.mac))
+	}
+	return sb.String()
+}
+
+func (nd netdev) String() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("-netdev %s,id=%s", nd.nettype, nd.id))
+	if len(nd.ifname) > 0 {
+		sb.WriteString(fmt.Sprintf(",ifname=%s", nd.ifname))
+	}
+	if nd.nettype != "user" {
+		if len(nd.script) > 0 {
+			sb.WriteString(fmt.Sprintf(",script=%s", nd.script))
+		} else {
+			sb.WriteString(",script=no")
+		}
+		if len(nd.downscript) > 0 {
+			sb.WriteString(fmt.Sprintf(",downscript=%s", nd.downscript))
+		} else {
+			sb.WriteString(",downscript=no")
+		}
+	}
+	for _, hport := range nd.hports {
+		sb.WriteString(fmt.Sprintf(",%s", hport))
+	}
+	return sb.String()
+}
+
+func (pf portfwd) String() string {
+	return fmt.Sprintf("hostfwd=%s::%v-:%v", pf.proto, pf.port, pf.port)
 }
 
 func (q *qemu) Stop() {
@@ -38,6 +115,7 @@ func (q *qemu) Stop() {
 		q.cmd.Process.Kill()
 	}
 }
+
 func logv(rconfig *RunConfig, msg string) {
 	if rconfig.Verbose {
 		fmt.Println(msg)
@@ -46,14 +124,14 @@ func logv(rconfig *RunConfig, msg string) {
 
 func (q *qemu) Command(rconfig *RunConfig) *exec.Cmd {
 	args := q.Args(rconfig)
-	q.cmd = exec.Command("qemu-system-x86_64", args...)
+	q.cmd = exec.Command(qemuBaseCommand, args...)
 	return q.cmd
 }
 
 func (q *qemu) Start(rconfig *RunConfig) error {
 	args := q.Args(rconfig)
-	logv(rconfig, "qemu-system-x86_64 "+strings.Join(args, " "))
-	q.cmd = exec.Command("qemu-system-x86_64", args...)
+	logv(rconfig, qemuBaseCommand+" "+strings.Join(args, " "))
+	q.cmd = exec.Command(qemuBaseCommand, args...)
 	q.cmd.Stdout = os.Stdout
 	q.cmd.Stdin = os.Stdin
 	q.cmd.Stderr = os.Stderr
@@ -66,36 +144,37 @@ func (q *qemu) Start(rconfig *RunConfig) error {
 }
 
 func (q *qemu) Args(rconfig *RunConfig) []string {
-	// TODO : this should come from q.drives and ifaces
-	args := []string{}
-
-	boot := []string{"-drive", "file=image,format=raw,index=0"}
-	storage := []string{"-drive", "file=image,format=raw,if=virtio"}
-	var net []string
-	if rconfig.Bridged {
-		net = []string{"-device", "virtio-net,mac=7e:b8:7e:87:4a:ea,netdev=n0",
-			"-netdev", "tap,id=n0,ifname=tap0,script=no,downscript=no"}
-
-	} else {
-		// hostfwd=tcp::8080-:8080
-		portfw := []string{}
-		for _, port := range rconfig.Ports {
-			portfw = append(portfw,
-				fmt.Sprintf("hostfwd=tcp::%v-:%v", port, port))
+	boot := drive{path: "image", format: "raw", index: "0"}
+	storage := drive{path: "image", format: "raw", iftype: "virtio"}
+	dev := device{driver: "virtio-net", mac: "7e:b8:7e:87:4a:ea", netdevid: "n0"}
+	ndev := netdev{nettype: "tap", id: "n0", ifname: "tap0"}
+	display := display{disptype: "none"}
+	serial := serial{serialtype: "stdio"}
+	if !rconfig.Bridged {
+		hps := []portfwd{}
+		for _, p := range rconfig.Ports {
+			hps = append(hps, portfwd{port: p, proto: "tcp"})
 		}
-		net = []string{"-device", "virtio-net,netdev=n0", "-netdev",
-			"user,id=n0," + strings.Join(portfw, ",")}
+		dev = device{driver: "virtio-net", netdevid: "n0"}
+		ndev = netdev{nettype: "user", id: "n0", hports: hps}
 	}
-	display := []string{"-display", "none", "-serial", "stdio"}
-	args = append(args, boot...)
-	args = append(args, display...)
-	args = append(args, []string{"-nodefaults", "-no-reboot", "-m", rconfig.Memory, "-device", "isa-debug-exit"}...)
-	args = append(args, storage...)
-	args = append(args, net...)
+	args := []string{
+		boot.String(),
+		display.String(),
+		serial.String(),
+		"-nodefaults",
+		"-no-reboot",
+		"-m", rconfig.Memory,
+		"-device", "isa-debug-exit",
+		storage.String(),
+		dev.String(),
+		ndev.String(),
+	}
 	if rconfig.Bridged {
 		args = append(args, "-enable-kvm")
 	}
-	return args
+	// The returned args must tokenized by whitespace
+	return strings.Fields(strings.Join(args, " "))
 }
 
 func newQemu() Hypervisor {

--- a/lepton/qemu_test.go
+++ b/lepton/qemu_test.go
@@ -1,0 +1,72 @@
+package lepton
+
+import (
+	. "fmt"
+	"testing"
+)
+
+func TestStringDriveWithIndex(t *testing.T) {
+	testDrive := &drive{path: "image", format: "raw", index: "0"}
+	expected := "-drive file=image,format=raw,index=0"
+	checkQemuString(testDrive, expected, t)
+}
+
+func TestStringDriveWithIfType(t *testing.T) {
+	testDrive := &drive{path: "image", format: "raw", iftype: "virtio"}
+	expected := "-drive file=image,format=raw,if=virtio"
+	checkQemuString(testDrive, expected, t)
+}
+
+func TestStringDevice(t *testing.T) {
+	testDevice := &device{driver: "virtio-net", mac: "7e:b8:7e:87:4a:ea", netdevid: "n0"}
+	expected := "-device virtio-net,netdev=n0,mac=7e:b8:7e:87:4a:ea"
+	checkQemuString(testDevice, expected, t)
+}
+
+func TestStringNetDev(t *testing.T) {
+	testNetDev := &netdev{
+		nettype:    "tap",
+		id:         "n0",
+		ifname:     "tap0",
+		script:     "no",
+		downscript: "no",
+	}
+	expected := "-netdev tap,id=n0,ifname=tap0,script=no,downscript=no"
+	checkQemuString(testNetDev, expected, t)
+}
+
+func TestStringNetDevWithHostPortForwarding(t *testing.T) {
+	testHostPorts := []portfwd{{proto: "tcp", port: 80}, {proto: "tcp", port: 443}}
+	testNetDev := &netdev{nettype: "tap", id: "n0", hports: testHostPorts}
+	expected := "-netdev tap,id=n0,script=no,downscript=no,hostfwd=tcp::80-:80,hostfwd=tcp::443-:443"
+	checkQemuString(testNetDev, expected, t)
+}
+
+func TestStringNetDevWithTypeUser(t *testing.T) {
+	// The 'downscript' and 'script' parameters are not valid for 'user'
+	// device type so we don't render them to the string in that case even
+	// if they are populated in the type.
+	testHostPorts := []portfwd{{proto: "tcp", port: 80}, {proto: "tcp", port: 443}}
+	testNetDev := &netdev{nettype: "user", id: "n0", downscript: "no", script: "no", hports: testHostPorts}
+	expected := "-netdev user,id=n0,hostfwd=tcp::80-:80,hostfwd=tcp::443-:443"
+	checkQemuString(testNetDev, expected, t)
+}
+
+func TestStringDisplay(t *testing.T) {
+	testDisplay := &display{disptype: "none"}
+	expected := "-display none"
+	checkQemuString(testDisplay, expected, t)
+}
+
+func TestStringSerial(t *testing.T) {
+	testSerial := &serial{serialtype: "stdio"}
+	expected := "-serial stdio"
+	checkQemuString(testSerial, expected, t)
+}
+
+func checkQemuString(qr Stringer, expected string, t *testing.T) {
+	actual := qr.String()
+	if expected != actual {
+		t.Errorf("Rendered string %q not %q", actual, expected)
+	}
+}


### PR DESCRIPTION
This is a refactor. The idea is to make it easy to simply transform a `RunConfig` into a "Qemu" struct (or just to take a `RunConfig` and convert it into qemu command line string). The next step is to get the correct parameters onto the cli and into the `RunConfig` to complete issues https://github.com/nanovms/ops/issues/173 and https://github.com/nanovms/ops/issues/177.

I have unit test and I have successfully run the commands with the various options but if you agree with this commit please eye the rendering functions to ensure I did not miss anything that will break the rendering of a qemu command.  