### PR TITLE
Removed ide drive mapping as it's not neeed after nanovms/nanos#480

### DIFF
--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -214,6 +214,7 @@ func (q *qemu) addOption(flag, value string) {
 }
 
 func (q *qemu) setConfig(rconfig *RunConfig) {
+	// add virtio drive
 	q.addDrive(rconfig.Imagename, "virtio")
 	devType := "user"
 	ifaceName := ""

--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -214,7 +214,6 @@ func (q *qemu) addOption(flag, value string) {
 }
 
 func (q *qemu) setConfig(rconfig *RunConfig) {
-	q.addDrive(rconfig.Imagename, "ide") // boot device must be ide for some reason
 	q.addDrive(rconfig.Imagename, "virtio")
 	devType := "user"
 	ifaceName := ""


### PR DESCRIPTION
For #125
After change nanovms/nanos#480, there is no need to map the same image twice to qemu. Removed "ide" mapping, as it's not used anymore bo boot.
