### PR TITLE
Auto install haxm.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -208,10 +208,28 @@ ops_install_haxm() {
     # installed or if the haxm kext was otherwise loaded. 
     existing_install=`pkgutil --pkgs | grep haxm`
     loaded_module=`kextstat | grep intelhaxm`
-    if [ ! -z $existing_install ] || [ ! -z $loaded_module ]; then
+    if [ ! -z "$existing_install" ] || [ ! -z $loaded_module ]; then
         return
     fi
 
+    while true; do
+	prompt="Would you like to install Intel HAXM for hypervisor hardware acceleration support [yes/NO]? "
+	read -p "$prompt"
+	reply=`echo $REPLY | tr '[:upper:]' '[:lower:]'`
+
+	if [ -z "$reply" ]; then
+	    reply="no"
+	fi
+
+	case "$reply" in
+	    no) return
+		;;
+	    yes) break
+		;;
+	    *) echo "Valid responses are either \"yes\" or \"no\"".
+	esac
+     done
+    
     # get the binary package. No need to check the md5 since the we are going
     # for the included .dmg which is signed.
     curl -LJO https://github.com/intel/haxm/releases/download/v7.4.1/haxm-macosx_v7_4_1.zip

--- a/install.sh
+++ b/install.sh
@@ -206,14 +206,14 @@ ops_install_haxm() {
 
     # check to see if a version of the package was previously
     # installed or if the haxm kext was otherwise loaded. 
-    existing_install=`pkgutil --pkgs | grep haxm`
-    loaded_module=`kextstat | grep intelhaxm`
+    readonly existing_install=`pkgutil --pkgs | grep haxm`
+    readonly loaded_module=`kextstat | grep intelhaxm`
     if [ ! -z "$existing_install" ] || [ ! -z $loaded_module ]; then
         return
     fi
 
     while true; do
-	prompt="Would you like to install Intel HAXM for hypervisor hardware acceleration support [yes/NO]? "
+	readonly prompt="Would you like to install Intel HAXM for hypervisor hardware acceleration support [yes/NO]? "
 	read -p "$prompt"
 	reply=`echo $REPLY | tr '[:upper:]' '[:lower:]'`
 
@@ -235,8 +235,9 @@ ops_install_haxm() {
     curl -LJO https://github.com/intel/haxm/releases/download/v7.4.1/haxm-macosx_v7_4_1.zip
     tar -xvf haxm-macosx_v7_4_1.zip -C /tmp
     hdiutil attach /tmp/IntelHAXM_7.4.1.dmg
-    installer -package /Volumes/IntelHAXM_7.4.1/IntelHAXM_7.4.1.mpkg -target /
+    sudo installer -package /Volumes/IntelHAXM_7.4.1/IntelHAXM_7.4.1.mpkg -target /
     hdiutil detach /Volumes/IntelHAXM_7.4.1/
+    rm -f haxm-macosx_v7_4_1.zip
 }
 
 ops_link() {

--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -238,7 +238,7 @@ func (q *qemu) setConfig(rconfig *RunConfig) {
 		devType = "tap"
 		ifaceName = rconfig.TapName
 		if runtime.GOOS == "darwin" {
-			q.addFlag("-enable-hax")
+			q.addFlag("-accel hax")
 		} else {
 			q.addFlag("-enable-kvm")
 		}

--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -238,7 +238,7 @@ func (q *qemu) setConfig(rconfig *RunConfig) {
 		devType = "tap"
 		ifaceName = rconfig.TapName
 		if runtime.GOOS == "darwin" {
-			q.addFlag("-accel hax")
+			q.addOption("-accel", "hax")
 		} else {
 			q.addFlag("-enable-kvm")
 		}

--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 )
@@ -236,7 +237,11 @@ func (q *qemu) setConfig(rconfig *RunConfig) {
 	if rconfig.Bridged {
 		devType = "tap"
 		ifaceName = rconfig.TapName
-		q.addFlag("-enable-kvm")
+		if runtime.GOOS == "darwin" {
+			q.addFlag("-enable-hax")
+		} else {
+			q.addFlag("-enable-kvm")
+		}
 	}
 	q.addDevice(devType, ifaceName, "", rconfig.Ports)
 	q.addDisplay("none")

--- a/lepton/qemu_test.go
+++ b/lepton/qemu_test.go
@@ -76,7 +76,7 @@ func TestRandomMacGen(t *testing.T) {
 func TestAcceleration(t *testing.T) {
 	expected := "-enable-kvm"
 	if runtime.GOOS == "darwin" {
-		expected = "-accel hax"
+		expected = "hax"
 	}
 	hv := &qemu{}
 	rc := RunConfig{Bridged: true}

--- a/lepton/qemu_test.go
+++ b/lepton/qemu_test.go
@@ -76,7 +76,7 @@ func TestRandomMacGen(t *testing.T) {
 func TestAcceleration(t *testing.T) {
 	expected := "-enable-kvm"
 	if runtime.GOOS == "darwin" {
-		expected = "-enable-hax"
+		expected = "-accel hax"
 	}
 	hv := &qemu{}
 	rc := RunConfig{Bridged: true}

--- a/lepton/qemu_test.go
+++ b/lepton/qemu_test.go
@@ -2,6 +2,7 @@ package lepton
 
 import (
 	. "fmt"
+	"runtime"
 	"testing"
 )
 
@@ -70,6 +71,22 @@ func TestRandomMacGen(t *testing.T) {
 	if len(q.devices[0].mac) == 0 {
 		t.Errorf("No RandomMac was Assigned %s", q.devices[0].mac)
 	}
+}
+
+func TestAcceleration(t *testing.T) {
+	expected := "-enable-kvm"
+	if runtime.GOOS == "darwin" {
+		expected = "-enable-hax"
+	}
+	hv := &qemu{}
+	rc := RunConfig{Bridged: true}
+	for _, arg := range hv.Args(&rc) {
+		if expected == arg {
+			return
+		}
+	}
+
+	t.Errorf("qemu flags should have included %q but did not.", expected)
 }
 
 func checkQemuString(qr Stringer, expected string, t *testing.T) {


### PR DESCRIPTION
Things to do: https://github.com/nanovms/ops/issues/141

- [x] ~enumerate osx version to determine what .dmg should be loaded~
- [x] prompt but don't demand the user install hax
- [x] need perms request in installer
- [ ] possibly create new signed dmgs
- [x] implement kexst check for osx (to see if there is hax enabled)
- [ ] re-eval perms issues to make this easy for end-users - i'm kinda thinking that if the installer script can be smart enough to detect vt-x and friends it should just go ahead and setup necessary permissions so that the user can run this stuff w/out sudo everytime - there's an implication here that most real deployments are going to be pushed through public clouds regardless so it's a bit of a mute issue for local
- [x] use acceleration flag appropriate to host OS.

