### PR TITLE
Add accel hvf flag

### DIFF
--- a/lepton/hv_support_darwin.go
+++ b/lepton/hv_support_darwin.go
@@ -1,0 +1,65 @@
+package lepton
+
+import (
+	"C"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func hv_support() (bool, error) {
+	name, err := unix.ByteSliceFromString("kern.hv_support")
+	if err != nil {
+		return false, err
+	}
+
+	// allocate the mib result buffer
+	var buf [unix.CTL_MAXNAME + 2]C.int
+	bufBytes := (*byte)(unsafe.Pointer(&buf[0]))
+	sz := unsafe.Sizeof(buf[0])
+	bufLen := uintptr(unix.CTL_MAXNAME) * sz
+
+	// make system call to read in the mib
+	if err = sysctl([]C.int{0, 3}, bufBytes, &bufLen, &name[0], uintptr(len(name))); err != nil {
+		return false, err
+	}
+	mib := []C.int(buf[0 : bufLen/sz])
+
+	// allocate the VT-X support result buffer
+	var resBuf C.int
+	resBufBytes := (*byte)(unsafe.Pointer(&resBuf))
+	sz = unsafe.Sizeof(resBuf)
+
+	// make the system call to read in the VT-X support result
+	var nullPtr uintptr
+	if err := sysctl(mib, resBufBytes, &sz, nil, nullPtr); err != nil {
+		return false, err
+	}
+
+	return resBuf != 0, nil
+}
+
+func sysctl(mib []C.int, old *byte, oldlen *uintptr, new *byte, newlen uintptr) (err error) {
+	var _zero uintptr
+	var _p0 unsafe.Pointer
+	if len(mib) > 0 {
+		_p0 = unsafe.Pointer(&mib[0])
+	} else {
+		_p0 = unsafe.Pointer(&_zero)
+	}
+	_, _, e1 := unix.Syscall6(
+		unix.SYS___SYSCTL,
+		uintptr(_p0),
+		uintptr(len(mib)),
+		uintptr(unsafe.Pointer(old)),
+		uintptr(unsafe.Pointer(oldlen)),
+		uintptr(unsafe.Pointer(new)),
+		uintptr(newlen))
+	if e1 != 0 {
+		return os.NewSyscallError("sysctl",
+			fmt.Errorf("%d", e1))
+	}
+	return
+}

--- a/lepton/hv_support_linux.go
+++ b/lepton/hv_support_linux.go
@@ -1,0 +1,37 @@
+package lepton
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func hv_support() (bool, error) {
+	const intel string = "vmx"
+	const amd string = "svm"
+
+	b, err := ioutil.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return false, err
+	}
+
+	content := string(b)
+	lines := strings.Split(content, "\n")
+
+	for _, line := range lines {
+		kvp := strings.Split(line, ":")
+		if len(kvp) == 0 {
+			continue
+		}
+		if strings.TrimSpace(kvp[0]) != "flags" {
+			continue
+		}
+		for _, flag := range strings.Split(kvp[1], " ") {
+			if flag == intel || flag == amd {
+				return true, nil
+			}
+			continue
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
Here we implement a virtualization hardware support check by making the system call on `Darwin` and by reading `/proc/cpuinfo` on `Linux`. We use this to know if we should add an `-accel` option to qemu. In neither case do we shell. 

However with this I have noticed that, while ` qemu  -accel-hvf ` works fine on `macos`; when using `-accel kvm` on `linux` qemu hangs when running an ops image. I've tested this with a `helloworld.go` image on my `AMD Ryzen` host. I'll certainly test  some more on other machine archs and distributions. 

TODO:

- [x] Have installer prompt to add user to `kvm` group on linux.
- [x] Do a `qemu` version check to know what flags/options to add.
- [x] Do User group check before adding flag
- [x] Find out why adding `-accel kvm/-enable kvm` causes the ops generated `qemu` command to hang. ~(I've tried this command with a minix3 image and it also hangs so its probably qemu and not the ops image - I'm digging through bug reports and docs - some old bug reports say that the command hangs when adding -enable-kvm but also report that the problem has been fixed)~
