### PR TITLE
Add USER environment variable by default.

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -192,6 +192,7 @@ func addFromConfig(m *Manifest, c *Config) {
 		m.AddDebugFlag(dbg, 't')
 	}
 
+	m.AddEnvironmentVariable("USER", "root")
 	for k, v := range c.Env {
 		m.AddEnvironmentVariable(k, v)
 	}


### PR DESCRIPTION
This magically fixes running with acceleration enabled (ops run -x).