### PR TITLE
Implement $ORIGIN expansion for DT_RPATH and DT_RUNPATH

### DIFF
--- a/lepton/ldd_darwin.go
+++ b/lepton/ldd_darwin.go
@@ -46,7 +46,11 @@ func lookupFile(targetRoot string, path string) (string, error) {
 	return targetPath, nil
 }
 
-func findLib(targetRoot string, libDirs []string, path string) (string, error) {
+func expandVars(origin string, s string) string {
+	return strings.Replace(s, "$ORIGIN", origin, -1)
+}
+
+func findLib(targetRoot string, origin string, libDirs []string, path string) (string, error) {
 	if path[0] == '/' {
 		if _, err := lookupFile(targetRoot, path); err != nil {
 			return "", err
@@ -55,7 +59,7 @@ func findLib(targetRoot string, libDirs []string, path string) (string, error) {
 	}
 
 	for _, libDir := range libDirs {
-		lib := filepath.Join(libDir, path)
+		lib := filepath.Join(expandVars(origin, libDir), path)
 		_, err := lookupFile(targetRoot, lib)
 		if err == nil {
 			return lib, nil
@@ -79,21 +83,37 @@ func _getSharedLibs(targetRoot string, path string) ([]string, error) {
 	}
 	defer fd.Close()
 
+	var libDirs []string
+
+	// 1. LD_LIBRARY_PATH
+	var ld_library_path []string
+	val := os.Getenv("LD_LIBRARY_PATH")
+	if len(strings.TrimSpace(val)) > 0 {
+		ld_library_path = strings.Split(val, ":")
+	}
+
+	// 2. DT_RUNPATH
 	dt_runpath, err := fd.DynString(elf.DT_RUNPATH)
 	if err != nil {
 		return nil, err
 	}
 	if len(dt_runpath) == 0 {
-		if dt_runpath, err = fd.DynString(elf.DT_RPATH); err != nil {
+		// DT_RPATH should take precedence over LD_LIBRARY_PATH
+		dt_rpath, err := fd.DynString(elf.DT_RPATH)
+		if err != nil {
 			return nil, err
 		}
+		for _, d := range dt_rpath {
+			libDirs = append(libDirs, strings.Split(d, ":")...)
+		}
+		libDirs = append(libDirs, ld_library_path...)
+	} else {
+		libDirs = append(libDirs, ld_library_path...)
+		for _, d := range dt_runpath {
+			libDirs = append(libDirs, strings.Split(d, ":")...)
+		}
 	}
-	dt_runpath = append(dt_runpath, "/lib64", "/lib/x86_64-linux-gnu", "/usr/lib", "/usr/lib64", "/usr/lib/x86_64-linux-gnu")
-
-	val := os.Getenv("LD_LIBRARY_PATH")
-	if len(strings.TrimSpace(val)) > 0 {
-		dt_runpath = append(dt_runpath, val)
-	}
+	libDirs = append(libDirs, "/lib64", "/lib/x86_64-linux-gnu", "/usr/lib", "/usr/lib64", "/usr/lib/x86_64-linux-gnu")
 
 	dt_needed, err := fd.DynString(elf.DT_NEEDED)
 	if err != nil {
@@ -107,7 +127,7 @@ func _getSharedLibs(targetRoot string, path string) ([]string, error) {
 		}
 
 		// append library
-		absLibpath, err := findLib(targetRoot, dt_runpath, libpath)
+		absLibpath, err := findLib(targetRoot, filepath.Dir(path), libDirs, libpath)
 		if err != nil {
 			return nil, errors.WrapPrefix(err, libpath, 0)
 		}


### PR DESCRIPTION
- Fix LD_LIBRARY_PATH/DT_RPATH/DT_RUNPATH precedence. From man 8 ld-linux.so:

       If a shared object dependency does not contain a slash, then it is searched
       for in the following order:

       o  Using the directories specified in the DT_RPATH dynamic section attribute
          of the binary if present and DT_RUNPATH attribute does not exist.
          Use of DT_RPATH is deprecated.

       o  Using the environment variable LD_LIBRARY_PATH (unless the executable is
          being run in secure-execution mode; see below in which case it is ignored).

       o  Using the directories specified in the DT_RUNPATH dynamic section attribute
          of the binary if present.

- LD_LIBRARY_PATH, DT_RPATH, DT_RUNPATH can contain multiple entries separated by ':'

- Implement $ORIGIN token expansion for DT_RPATH and DT_RUNPATH