### PR TITLE
Don't chmod in linux getSharedLibs

### DIFF
--- a/lepton/ldd_test.go
+++ b/lepton/ldd_test.go
@@ -15,3 +15,13 @@ func TestGetSharedLibs(t *testing.T) {
 		t.Fatal("No deps for ../data/webg")
 	}
 }
+
+func TestGetSharedLibsSystemLs(t *testing.T) {
+	if _, err := os.Stat("/bin/ls"); err != nil {
+		t.Skip("could not stat /bin/ls:", err)
+	}
+	targetRoot := os.Getenv("NANOS_TARGET_ROOT")
+	if _, err := getSharedLibs(targetRoot, "/bin/ls"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Calling os.Chmod will fail if the current user doesn't have write permission
for a given file, but can still run ldd (e.g., /bin/ls). This patch just
leaves the permissions alone and lets ldd fail if there's no execution
rights.

I see the chmod was added in 3a3ba2307b24aa15ed50d38d4800f5e9cd2ea76b but I can't figure out what path expects execute permissions to not be set. If a binary doesn't have +x set, it seems safer to have the user choose to grant the permission after seeing an error instead of automatically clobbering the mode with 755.

/cc @tijoytom 