### PR TITLE
quote/escape filenames in manifest if needed

### DIFF
--- a/lepton/manifest.go
+++ b/lepton/manifest.go
@@ -211,7 +211,11 @@ func (m *Manifest) String() string {
 	sb.WriteString("arguments:[")
 	if len(m.args) > 0 {
 		fmt.Println(m.args)
-		sb.WriteString(strings.Join(m.args, " "))
+		escapedArgs := make([]string, len(m.args))
+		for i, arg := range m.args {
+			escapedArgs[i] = escapeValue(arg)
+		}
+		sb.WriteString(strings.Join(escapedArgs, " "))
 	}
 	sb.WriteString("]\n")
 
@@ -237,7 +241,7 @@ func (m *Manifest) String() string {
 		n = n - 1
 		sb.WriteString(k)
 		sb.WriteRune(':')
-		sb.WriteString(v)
+		sb.WriteString(escapeValue(v))
 		if n > 0 {
 			sb.WriteRune(' ')
 		}

--- a/lepton/manifest.go
+++ b/lepton/manifest.go
@@ -185,6 +185,16 @@ func (m *Manifest) AddUserData(dir string) {
 	// TODO
 }
 
+func escapeValue(s string) string {
+	if strings.Contains(s, "\"") {
+		s = strings.Replace(s, "\"", "\\\"", -1)
+	}
+	if strings.ContainsAny(s, "\":()[] \t\n") {
+		s = "\"" + s + "\""
+	}
+	return s
+}
+
 func (m *Manifest) String() string {
 	sb := m.sb
 	sb.WriteString("(\n")
@@ -244,9 +254,9 @@ func toString(m *map[string]interface{}, sb *strings.Builder, indent int) {
 		value, ok := v.(string)
 		sb.WriteString(strings.Repeat(" ", indent))
 		if ok {
-			sb.WriteString(k)
+			sb.WriteString(escapeValue(k))
 			sb.WriteString(":(contents:(host:")
-			sb.WriteString(value)
+			sb.WriteString(escapeValue(value))
 			sb.WriteString("))\n")
 		} else {
 			sb.WriteString(k)


### PR DESCRIPTION
This will allow to fix nanovms/nanos#427. Works only with nanovms/nanos#822