### PR TITLE
Fix nanos go tests on macOS

### DIFF
--- a/lepton/ldd_darwin.go
+++ b/lepton/ldd_darwin.go
@@ -9,43 +9,6 @@ import (
 	"github.com/go-errors/errors"
 )
 
-func lookupFile(targetRoot string, path string) (string, error) {
-	if targetRoot != "" {
-		var targetPath string
-		currentPath := path
-		for {
-			targetPath = filepath.Join(targetRoot, currentPath)
-			fi, err := os.Lstat(targetPath)
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return path, err
-				}
-				// lookup on host
-				break
-			}
-			if fi.Mode()&os.ModeSymlink == 0 {
-				// not a symlink found in target root
-				return targetPath, nil
-			}
-
-			currentPath, err = os.Readlink(targetPath)
-			if err != nil {
-				return path, err
-			}
-			if currentPath[0] != '/' {
-				// relative symlinks are ok
-				path = targetPath
-				break
-			}
-
-			// absolute symlinks need to be resolved again
-		}
-	}
-
-	_, err := os.Stat(path)
-	return path, err
-}
-
 func expandVars(origin string, s string) string {
 	return strings.Replace(s, "$ORIGIN", origin, -1)
 }

--- a/lepton/manifest.go
+++ b/lepton/manifest.go
@@ -18,14 +18,16 @@ type Manifest struct {
 	debugFlags  map[string]rune
 	noTrace     []string
 	environment map[string]string
+	targetRoot  string
 }
 
 // NewManifest init
-func NewManifest() *Manifest {
+func NewManifest(targetRoot string) *Manifest {
 	return &Manifest{
 		children:    make(map[string]interface{}),
 		debugFlags:  make(map[string]rune),
 		environment: make(map[string]string),
+		targetRoot:  targetRoot,
 	}
 }
 
@@ -158,7 +160,7 @@ func (m *Manifest) AddFile(filepath string, hostpath string) error {
 	if pathtest != nil && reflect.TypeOf(pathtest).Kind() == reflect.String && node[parts[len(parts)-1]] != hostpath {
 		fmt.Printf("warning: overwriting existing file %s hostpath old: %s new: %s\n", filepath, node[parts[len(parts)-1]], hostpath)
 	}
-	_, err := os.Stat(hostpath)
+	_, err := lookupFile(m.targetRoot, hostpath)
 	if err != nil {
 		return err
 	}

--- a/lepton/manifest_test.go
+++ b/lepton/manifest_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 func TestAddKernel(t *testing.T) {
-	m := NewManifest()
+	m := NewManifest("")
 	m.AddKernel("stage3/stage3")
 	var sb strings.Builder
 	toString(&m.children, &sb, 0)
@@ -32,7 +32,7 @@ func TestAddKernel(t *testing.T) {
 }
 
 func TestAddRelativePath(t *testing.T) {
-	m := NewManifest()
+	m := NewManifest("")
 	m.AddRelative("hw", "examples/hw")
 	var sb strings.Builder
 	toString(&m.children, &sb, 0)
@@ -43,7 +43,7 @@ func TestAddRelativePath(t *testing.T) {
 }
 
 func TestAddLibs(t *testing.T) {
-	m := NewManifest()
+	m := NewManifest("")
 	m.AddLibrary("/lib/x86_64-linux-gnu/libc.so.6")
 	var sb strings.Builder
 	toString(&m.children, &sb, 0)
@@ -66,7 +66,7 @@ func TestManifestWithDeps(t *testing.T) {
 }
 
 func TestSerializeManifest(t *testing.T) {
-	m := NewManifest()
+	m := NewManifest("")
 	m.AddUserProgram("/bin/ls")
 	m.AddKernel("stage3/stage3")
 	m.AddArgument("first")


### PR DESCRIPTION
Some files are added from $NANOS_TARGET_ROOT so check their existence also there.

AddDirectory() should also probably be fixed in this way but it never
was able to lookup in target root.