### PR TITLE
Add gdb enable and port flag to ops run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,6 +37,11 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	gdbport, err := cmd.Flags().GetInt("gdbport")
+	if err != nil {
+		panic(err)
+	}
+
 	noTrace, err := cmd.Flags().GetStringArray("no-trace")
 	if err != nil {
 		panic(err)
@@ -94,6 +99,7 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 	if debugflags {
 		c.Debugflags = []string{"trace", "debugsyscalls", "futex_trace", "fault"}
 	}
+	c.RunConfig.GdbPort = gdbport
 	c.TargetRoot = targetRoot
 
 	c.RunConfig.TapName = tapDeviceName
@@ -123,6 +129,11 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 		if err != nil {
 			panic(err)
 		}
+
+		if i == gdbport {
+			errstr := fmt.Sprintf("Port %d is forwarded and cannot be used as gdb port", gdbport)
+			panic(errors.New(errstr))
+		}
 		ports = append(ports, i)
 	}
 
@@ -137,6 +148,7 @@ func RunCommand() *cobra.Command {
 	var ports []string
 	var force bool
 	var debugflags bool
+	var gdbport int
 	var noTrace []string
 	var args []string
 	var verbose bool
@@ -161,6 +173,7 @@ func RunCommand() *cobra.Command {
 	cmdRun.PersistentFlags().BoolVarP(&force, "force", "f", false, "update images")
 	cmdRun.PersistentFlags().BoolVarP(&nightly, "nightly", "n", false, "nightly build")
 	cmdRun.PersistentFlags().BoolVarP(&debugflags, "debug", "d", false, "enable all debug flags")
+	cmdRun.PersistentFlags().IntVarP(&gdbport, "gdbport", "g", 0, "qemu TCP port used for GDB interface")
 	cmdRun.PersistentFlags().StringArrayVarP(&noTrace, "no-trace", "", nil, "do not trace syscall")
 	cmdRun.PersistentFlags().StringArrayVarP(&args, "args", "a", nil, "command line arguments")
 	cmdRun.PersistentFlags().StringVarP(&config, "config", "c", "", "ops config file")

--- a/lepton/config.go
+++ b/lepton/config.go
@@ -37,6 +37,7 @@ type ProviderConfig struct {
 type RunConfig struct {
 	Imagename string
 	Ports     []int
+	GdbPort   int
 	Verbose   bool
 	Memory    string
 	Bridged   bool

--- a/lepton/qemu.go
+++ b/lepton/qemu.go
@@ -404,6 +404,11 @@ func (q *qemu) setConfig(rconfig *RunConfig) {
 	q.addFlag("-no-reboot")
 	q.addOption("-device", "isa-debug-exit")
 	q.addOption("-m", rconfig.Memory)
+
+	if rconfig.GdbPort > 0 {
+		gdbProtoStr := fmt.Sprintf("tcp::%d", rconfig.GdbPort)
+		q.addOption("-gdb", gdbProtoStr)
+	}
 }
 
 func (q *qemu) Args(rconfig *RunConfig) []string {


### PR DESCRIPTION
Added support for enabling qemu's GDB interface. Only debugging over TCP
is supported (fortunately, it's the most common option, and the most
useful for us), and the user can specify the TCP port to be used for the
gdb interface. Specifying a port also enables the gdb interface --
specifying one without the other would be meaningless, since only TCP is
supported.

Signed-off-by: Alexandru Lazar <alazar@startmail.com>