### PR TITLE
README.md: Fix goreport badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OPS
 
-[![CircleCI](https://circleci.com/gh/nanovms/ops.svg?style=svg)](https://circleci.com/gh/nanovms/ops) [![Go Report (https://goreportcard.com/badge/github.com/nanovms/ops)](https://goreportcard.com/badge/github.com/nanovms/ops) [![](https://godoc.org/github.com/nanovms/ops?status.svg)](http://godoc.org/github.com/nanovms/ops)
+[![CircleCI](https://circleci.com/gh/nanovms/ops.svg?style=svg)](https://circleci.com/gh/nanovms/ops)
+[![Go Report](https://goreportcard.com/badge/github.com/nanovms/ops)](https://goreportcard.com/report/github.com/nanovms/ops)
+[![](https://godoc.org/github.com/nanovms/ops?status.svg)](http://godoc.org/github.com/nanovms/ops)
 
 <p align="center">
   <img src="https://i.imgur.com/OtfAABU.png" style="width:200px;"/>


### PR DESCRIPTION
Add missing closing brace and replace duplicate link to the badge image
to report link.