### PR TITLE
Disable spinner for pkg list

### DIFF
--- a/lepton/package.go
+++ b/lepton/package.go
@@ -42,7 +42,7 @@ func DownloadPackage(name string) (string, error) {
 	archivename := name + ".tar.gz"
 	packagepath := path.Join(PackagesCache, archivename)
 	if _, err := os.Stat(packagepath); os.IsNotExist(err) {
-		if err = DownloadFile(packagepath,
+		if err = DownloadFileWithProgress(packagepath,
 			fmt.Sprintf(PackageBaseURL, archivename), 600); err != nil {
 			return "", err
 		}
@@ -57,7 +57,7 @@ func GetPackageList() *map[string]Package {
 	packageManifest := GetPackageManifestFile()
 	stat, err := os.Stat(packageManifest)
 	if os.IsNotExist(err) || PackageManifestChanged(stat, PackageManifestURL) {
-		if err = DownloadFile(packageManifest, PackageManifestURL, 10); err != nil {
+		if err = DownloadFile(packageManifest, PackageManifestURL, 10, false); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
These changes resolve #250 .

I have introduced a new parameter `showProgress` to the function `DownloadFile`. This allows the calling code to determine whether a progress spinner should print in the terminal for this download. I have added a useful helper function `DownloadFileWithProgress`, which conforms to the previous function signature, but sets `showProgress` to `true` automatically.

The instance where the package list should not display a spinner sets this explicitly to `false`. I can write a wrapper for this case too, but since this is the only occurrence it did not seem strictly essential at this stage. Let me know whether you would like me to add `DownloadFileWithoutProgress` as part of these changes too @eyberg ?