### PR TITLE
Print volume size in volume list table

### DIFF
--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 	"path"
+	"strconv"
 
 	api "github.com/nanovms/ops/lepton"
 	"github.com/spf13/cobra"
@@ -52,7 +53,7 @@ func volumeCreateCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 	}
 	cmdVolumeCreate.PersistentFlags().StringVarP(&data, "data", "d", "", "volume data source")
-	cmdVolumeCreate.PersistentFlags().StringVarP(&size, "size", "s", "", "volume initial size")
+	cmdVolumeCreate.PersistentFlags().StringVarP(&size, "size", "s", strconv.Itoa(api.MinimumVolumeSize), "volume initial size")
 	return cmdVolumeCreate
 }
 

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -128,11 +128,12 @@ func (v *Volume) GetAll() error {
 		return err
 	}
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAME", "UUID", "PATH"})
+	table.SetHeader([]string{"NAME", "UUID", "SIZE", "PATH"})
 	for _, vol := range vols {
 		var row []string
 		row = append(row, vol.Name)
 		row = append(row, vol.ID)
+		row = append(row, v.parseSize(vol))
 		row = append(row, vol.Path)
 		table.Append(row)
 	}
@@ -252,4 +253,16 @@ func (v *Volume) AttachOnRun(mount string) error {
 	conf.Mounts[uuid] = path
 	conf.RunConfig.Mounts = append(conf.RunConfig.Mounts, vol.Path)
 	return nil
+}
+
+func (v *Volume) parseSize(vol NanosVolume) string {
+	if vol.Size == "" {
+		return bytes2Human(MiByte)
+	}
+	bytes, err := parseBytes(vol.Size)
+	if err != nil {
+		log.Printf("warning: invalid size value for volume %s with UUID %s: %s", vol.Name, vol.ID, err.Error())
+	}
+	size := bytes2Human(bytes)
+	return size
 }

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -18,6 +18,9 @@ var (
 	localVolumeData = path.Join(GetOpsHome(), "volumes", "volumes.json")
 )
 
+// MinimumVolumeSize is the minimum size of a volume created with mkfs (1 MB).
+const MinimumVolumeSize = MByte
+
 var (
 	errVolumeNotFound = func(id string) error { return errors.Errorf("volume with UUID %s not found", id) }
 	errVolumeMounted  = func(id, image string) error {
@@ -255,8 +258,11 @@ func (v *Volume) AttachOnRun(mount string) error {
 	return nil
 }
 
+// parseSize parses the size of the NanosVolume to human readable format.
+// If the size value is empty, it returns 1 MB (the default size of volumes).
 func (v *Volume) parseSize(vol NanosVolume) string {
 	if vol.Size == "" {
+		// return the default size of a volume
 		return bytes2Human(MiByte)
 	}
 	bytes, err := parseBytes(vol.Size)


### PR DESCRIPTION
## Description
Prints the volume size alongside other values in the list volumes table. It first parses the size value into a human readable format using the helper functions in `lepton/helpers.go`.
Example
```bash
./ops volume list
+----------+--------------------------------------+--------+------------------------------------------------+
|   NAME   |                 UUID                 |  SIZE  |                      PATH                      |
+----------+--------------------------------------+--------+------------------------------------------------+
| test_vol | 9aa1a2a1-4d6d-a340-03d2-a77b05484c16 | 1.0 kB | /home/ahmedaabouzied/.ops/volumes/test_vol.raw |
+----------+--------------------------------------+--------+------------------------------------------------+
```
If there is an error parsing the size value of a certain volume, it prints an error instead indicating the name, ID of the volume with the invalid value as follows
```bash
./ops volume list
2020/09/23 04:45:57 invalid size value for volume test_vol with UUID 1352848a-547a-c67c-fce9-5f1e8e52bc8e: strconv.ParseFloat: parsing "": invalid syntax
```
Fixes #608 

### UPDATE
Fixes #638 as well