### PR TITLE
GCP mounting

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -158,8 +158,8 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 
 	if len(mounts) > 0 {
 		for _, mount := range mounts {
-			vol := api.NewVolume(c)
-			err := vol.AttachOnRun(mount)
+			vol := api.NewLocalVolume()
+			err := vol.AttachVolume("", "", mount, c)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -664,3 +664,35 @@ func (p *AWS) getArchiveName(ctx *Context) string {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath
 }
+
+// CreateVolume ...
+func (p *AWS) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (p *AWS) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (p *AWS) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (p *AWS) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (p *AWS) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (p *AWS) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/azure.go
+++ b/lepton/azure.go
@@ -679,3 +679,35 @@ func (a *Azure) GetInstanceLogs(ctx *Context, instancename string, watch bool) e
 func (a *Azure) ResizeImage(ctx *Context, imagename string, hbytes string) error {
 	return fmt.Errorf("Operation not supported")
 }
+
+// CreateVolume ...
+func (a *Azure) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (a *Azure) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (a *Azure) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (a *Azure) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (a *Azure) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (a *Azure) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/digital_ocean.go
+++ b/lepton/digital_ocean.go
@@ -177,3 +177,35 @@ func (do *DigitalOcean) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
 }
+
+// CreateVolume ...
+func (do *DigitalOcean) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (do *DigitalOcean) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (do *DigitalOcean) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (do *DigitalOcean) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (do *DigitalOcean) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (do *DigitalOcean) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/gcp.go
+++ b/lepton/gcp.go
@@ -587,7 +587,7 @@ func (p *GCloud) ResizeImage(ctx *Context, imagename string, hbytes string) erro
 	return fmt.Errorf("Operation not supported")
 }
 
-// Create creates local volume and converts it to GCP format before orchestrating the necessary upload procedures
+// CreateVolume creates local volume and converts it to GCP format before orchestrating the necessary upload procedures
 // TODO treat GCS object and Compute Image as temporary and delete after volume is created?
 func (p *GCloud) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
 	v := NewLocalVolume()

--- a/lepton/onprem.go
+++ b/lepton/onprem.go
@@ -254,3 +254,35 @@ func (p *OnPrem) GetInstanceLogs(ctx *Context, instancename string, watch bool) 
 func (p *OnPrem) Initialize() error {
 	return nil
 }
+
+// CreateVolume ...
+func (p *OnPrem) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (p *OnPrem) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (p *OnPrem) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (p *OnPrem) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (p *OnPrem) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (p *OnPrem) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/openstack.go
+++ b/lepton/openstack.go
@@ -486,3 +486,35 @@ func (o *OpenStack) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
 }
+
+// CreateVolume ...
+func (o *OpenStack) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (o *OpenStack) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (o *OpenStack) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (o *OpenStack) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (o *OpenStack) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (o *OpenStack) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -17,6 +17,7 @@ type Provider interface {
 	StopInstance(ctx *Context, instancename string) error
 	StartInstance(ctx *Context, instancename string) error
 	GetInstanceLogs(ctx *Context, instancename string, watch bool) error
+	VolumeService
 }
 
 // Context captures required info for provider operation

--- a/lepton/store.go
+++ b/lepton/store.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -164,27 +163,4 @@ func (s *JSONStore) Delete(id string) (NanosVolume, error) {
 		return vol, err
 	}
 	return vol, nil
-}
-
-func buildVolumeManifest(conf *Config, out string) error {
-	m := &Manifest{
-		children:    make(map[string]interface{}),
-		debugFlags:  make(map[string]rune),
-		environment: make(map[string]string),
-	}
-
-	for _, d := range conf.Dirs {
-		err := m.AddRelativeDirectory(d)
-		if err != nil {
-			return err
-		}
-	}
-
-	m.AddEnvironmentVariable("USER", "root")
-	m.AddEnvironmentVariable("PWD", "/")
-	for k, v := range conf.Env {
-		m.AddEnvironmentVariable(k, v)
-	}
-
-	return ioutil.WriteFile(out, []byte(m.String()), 0644)
 }

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -31,7 +31,7 @@ var (
 	errInvalidMountConfiguration = func(mount string) error { return errors.Errorf("%s: invalid mount configuration", mount) }
 )
 
-// Volume interface for volume related operations
+// VolumeService interface for volume related operations
 type VolumeService interface {
 	CreateVolume(name, data, size string, config *Config) (NanosVolume, error)
 	GetAllVolume(config *Config) error
@@ -72,7 +72,7 @@ func NewLocalVolume() *LocalVolume {
 	}
 }
 
-// Create creates local volume
+// CreateVolume creates local volume
 func (v *LocalVolume) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
 	var cmd *exec.Cmd
 	var vol NanosVolume
@@ -126,7 +126,7 @@ func (v *LocalVolume) CreateVolume(name, data, size string, config *Config) (Nan
 	return vol, nil
 }
 
-// GetAll gets list of all nanos-managed local volumes
+// GetAllVolume gets list of all nanos-managed local volumes
 func (v *LocalVolume) GetAllVolume(config *Config) error {
 	vols, err := v.store.GetAll()
 	if err != nil {
@@ -145,12 +145,12 @@ func (v *LocalVolume) GetAllVolume(config *Config) error {
 	return nil
 }
 
-// Get gets nanos-managed local volume by its UUID
+// GetVolume gets nanos-managed local volume by its UUID
 func (v *LocalVolume) GetVolume(id string, config *Config) (NanosVolume, error) {
 	return v.store.Get(id)
 }
 
-// Delete deletes nanos-managed local volume by its UUID
+// DeleteVolume deletes nanos-managed local volume by its UUID
 func (v *LocalVolume) DeleteVolume(id string, config *Config) error {
 	// delete from storage
 	vol, err := v.store.Delete(id)
@@ -167,7 +167,7 @@ func (v *LocalVolume) DeleteVolume(id string, config *Config) error {
 	return nil
 }
 
-// Attach attaches local volume to a stopped instance
+// AttachVolume attaches local volume to a stopped instance
 func (v *LocalVolume) AttachVolume(image, volume, mount string, config *Config) error {
 	um := strings.Split(mount, ":")
 	if len(um) < 2 {
@@ -199,7 +199,7 @@ func (v *LocalVolume) AttachVolume(image, volume, mount string, config *Config) 
 	return nil
 }
 
-// Detach detaches local volume to a stopped instance
+// DetachVolume detaches local volume to a stopped instance
 func (v *LocalVolume) DetachVolume(image, volume string, config *Config) error {
 	return nil
 }

--- a/lepton/vsphere.go
+++ b/lepton/vsphere.go
@@ -803,3 +803,35 @@ func (v *Vsphere) getCredentials() (*url.URL, error) {
 	u, err = url.Parse(tempURL + "/sdk")
 	return u, err
 }
+
+// CreateVolume ...
+func (v *Vsphere) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (v *Vsphere) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (v *Vsphere) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (v *Vsphere) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (v *Vsphere) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (v *Vsphere) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}

--- a/lepton/vultr.go
+++ b/lepton/vultr.go
@@ -383,3 +383,35 @@ func (v *Vultr) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
 }
+
+// CreateVolume ...
+func (v *Vultr) CreateVolume(name, data, size string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// GetAllVolume ...
+func (v *Vultr) GetAllVolume(config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// GetVolume ...
+func (v *Vultr) GetVolume(id string, config *Config) (NanosVolume, error) {
+	var vol NanosVolume
+	return vol, fmt.Errorf("Operation not supported")
+}
+
+// DeleteVolume ...
+func (v *Vultr) DeleteVolume(id string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// AttachVolume ...
+func (v *Vultr) AttachVolume(image, volume, mount string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}
+
+// DetachVolume ...
+func (v *Vultr) DetachVolume(image, volume string, config *Config) error {
+	return fmt.Errorf("Operation not supported")
+}


### PR DESCRIPTION
#585 
1. add `create`, `list`, `delete`, `attach`, and `detach` volume functionalities for GCP
2. additionally, refactor `GCloud` functions to reuse `compute.Service`

changes to non gcp-related providers are merely stubs to make `Provider` implements volume-related functionalities.