### PR TITLE
add image sync command

### DIFF
--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -365,6 +365,12 @@ func (p *AWS) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (p *AWS) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // CreateInstance - Creates instance on AWS Platform
 func (p *AWS) CreateInstance(ctx *Context) error {
 	result, err := getAWSImages(ctx.config.CloudConfig.Zone)
@@ -653,7 +659,6 @@ func (p *AWS) GetInstanceLogs(ctx *Context, instancename string, watch bool) err
 	return nil
 }
 
-// TODO - make me shared
 func (p *AWS) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
@@ -663,4 +668,9 @@ func (p *AWS) customizeImage(ctx *Context) (string, error) {
 func (p *AWS) getArchiveName(ctx *Context) string {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath
+}
+
+// GetStorage returns storage interface for cloud provider
+func (p *AWS) GetStorage() Storage {
+	return p.Storage
 }

--- a/lepton/azure.go
+++ b/lepton/azure.go
@@ -340,6 +340,12 @@ func (a *Azure) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (a *Azure) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // CreateInstance - Creates instance on azure Platform
 //
 // this is kind of a pita
@@ -678,4 +684,9 @@ func (a *Azure) GetInstanceLogs(ctx *Context, instancename string, watch bool) e
 // ResizeImage is not supported on azure.
 func (a *Azure) ResizeImage(ctx *Context, imagename string, hbytes string) error {
 	return fmt.Errorf("Operation not supported")
+}
+
+// GetStorage returns storage interface for cloud provider
+func (a *Azure) GetStorage() Storage {
+	return a.Storage
 }

--- a/lepton/digital_ocean.go
+++ b/lepton/digital_ocean.go
@@ -131,6 +131,12 @@ func (do *DigitalOcean) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (do *DigitalOcean) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // ResizeImage is not supported on Digital Ocean.
 func (do *DigitalOcean) ResizeImage(ctx *Context, imagename string, hbytes string) error {
 	return fmt.Errorf("Operation not supported")
@@ -172,8 +178,12 @@ func (do *DigitalOcean) GetInstanceLogs(ctx *Context, instancename string, watch
 	return nil
 }
 
-// TODO - make me shared
 func (do *DigitalOcean) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
+}
+
+// GetStorage returns storage interface for cloud provider
+func (do *DigitalOcean) GetStorage() Storage {
+	return do.Storage
 }

--- a/lepton/gcp.go
+++ b/lepton/gcp.go
@@ -313,6 +313,12 @@ func (p *GCloud) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (p *GCloud) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // CreateInstance - Creates instance on Google Cloud Platform
 func (p *GCloud) CreateInstance(ctx *Context) error {
 	if err := checkCredentialsProvided(); err != nil {
@@ -680,4 +686,9 @@ func createArchive(archive string, files []string) error {
 // ResizeImage is not supported on google cloud.
 func (p *GCloud) ResizeImage(ctx *Context, imagename string, hbytes string) error {
 	return fmt.Errorf("Operation not supported")
+}
+
+// GetStorage returns storage interface for cloud provider
+func (p *GCloud) GetStorage() Storage {
+	return p.Storage
 }

--- a/lepton/openstack.go
+++ b/lepton/openstack.go
@@ -222,6 +222,12 @@ func (o *OpenStack) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (o *OpenStack) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 func (o *OpenStack) findFlavorByName(name string) (id string, err error) {
 	client, err := openstack.NewComputeV2(o.provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
@@ -481,8 +487,12 @@ func (o *OpenStack) GetInstanceLogs(ctx *Context, instancename string, watch boo
 	return nil
 }
 
-// Todo - make me shared
 func (o *OpenStack) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
+}
+
+// GetStorage returns storage interface for cloud provider
+func (o *OpenStack) GetStorage() Storage {
+	return o.Storage
 }

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -3,6 +3,7 @@ package lepton
 // Provider is an interface that provider must implement
 type Provider interface {
 	Initialize() error
+
 	BuildImage(ctx *Context) (string, error)
 	BuildImageWithPackage(ctx *Context, pkgpath string) (string, error)
 	CreateImage(ctx *Context) error
@@ -10,6 +11,9 @@ type Provider interface {
 	GetImages(ctx *Context) ([]CloudImage, error)
 	DeleteImage(ctx *Context, imagename string) error
 	ResizeImage(ctx *Context, imagename string, hbytes string) error
+	SyncImage(config *Config, target Provider, imagename string) error
+	customizeImage(ctx *Context) (string, error)
+
 	CreateInstance(ctx *Context) error
 	ListInstances(ctx *Context) error
 	GetInstances(ctx *Context) ([]CloudInstance, error)
@@ -17,6 +21,13 @@ type Provider interface {
 	StopInstance(ctx *Context, instancename string) error
 	StartInstance(ctx *Context, instancename string) error
 	GetInstanceLogs(ctx *Context, instancename string, watch bool) error
+
+	GetStorage() Storage
+}
+
+// Storage is an interface that provider's storage must implement
+type Storage interface {
+	CopyToBucket(config *Config, source string) error
 }
 
 // Context captures required info for provider operation

--- a/lepton/vsphere.go
+++ b/lepton/vsphere.go
@@ -242,6 +242,12 @@ func (v *Vsphere) DeleteImage(ctx *Context, imagename string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (v *Vsphere) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // CreateInstance - Creates instance on VSphere.
 // Currently we support pvsci adapter && vmnetx3 network driver.
 func (v *Vsphere) CreateInstance(ctx *Context) error {
@@ -753,7 +759,6 @@ func (v *Vsphere) GetInstanceLogs(ctx *Context, instancename string, watch bool)
 	return nil
 }
 
-// Todo - make me shared
 func (v *Vsphere) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
@@ -802,4 +807,9 @@ func (v *Vsphere) getCredentials() (*url.URL, error) {
 	tempURL = fmt.Sprintf("%s://%s:%s@%s", u.Scheme, un, pw, u.Host)
 	u, err = url.Parse(tempURL + "/sdk")
 	return u, err
+}
+
+// GetStorage returns storage interface for cloud provider
+func (v *Vsphere) GetStorage() Storage {
+	return v.Storage
 }

--- a/lepton/vultr.go
+++ b/lepton/vultr.go
@@ -182,6 +182,12 @@ func (v *Vultr) DeleteImage(ctx *Context, snapshotID string) error {
 	return nil
 }
 
+// SyncImage syncs image from provider to another provider
+func (v *Vultr) SyncImage(config *Config, target Provider, image string) error {
+	fmt.Println("not yet implemented")
+	return nil
+}
+
 // ResizeImage is not supported on Vultr.
 func (v *Vultr) ResizeImage(ctx *Context, imagename string, hbytes string) error {
 	return fmt.Errorf("Operation not supported")
@@ -378,8 +384,12 @@ func (v *Vultr) GetInstanceLogs(ctx *Context, instancename string, watch bool) e
 	return nil
 }
 
-// TOv - make me shared
 func (v *Vultr) customizeImage(ctx *Context) (string, error) {
 	imagePath := ctx.config.RunConfig.Imagename
 	return imagePath, nil
+}
+
+// GetStorage returns storage interface for cloud provider
+func (v *Vultr) GetStorage() Storage {
+	return v.Storage
 }


### PR DESCRIPTION
resolves #502 

`ops image sync <image_name> -t <cloud_provider>` allows user to transfer locally existing image to target cloud provider

since original `ops image` does not accept flags for some provider-related configs, user will need to set said fields in config