### PR TITLE
Fix creation of non-empty volumes (#662)

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -368,7 +368,7 @@ func buildImage(c *Config, m *Manifest) error {
 	}
 
 	mkfsCommand.SetBoot(c.Boot)
-	mkfsCommand.SetImageName(c.RunConfig.Imagename)
+	mkfsCommand.SetFileSystemPath(c.RunConfig.Imagename)
 
 	mkfsCommand.SetupCommand()
 	stdin, err := mkfsCommand.GetStdinPipe()

--- a/lepton/mkfs.go
+++ b/lepton/mkfs.go
@@ -41,9 +41,9 @@ func (m *MkfsCommand) SetupCommand() {
 	}
 }
 
-// SetFileSystemPath add argument that sets file system path
-func (m *MkfsCommand) SetFileSystemPath(path string) {
-	m.args = append(m.args, "-e", path)
+// SetEmptyFileSystem add argument that sets file system as empty
+func (m *MkfsCommand) SetEmptyFileSystem() {
+	m.args = append(m.args, "-e")
 }
 
 // SetFileSystemSize add argument that sets file system size
@@ -61,9 +61,9 @@ func (m *MkfsCommand) SetBoot(boot string) {
 	m.args = append(m.args, "-b", boot)
 }
 
-// SetImageName add argument that sets
-func (m *MkfsCommand) SetImageName(imageName string) {
-	m.args = append(m.args, imageName)
+// SetFileSystemPath add argument that sets file system path
+func (m *MkfsCommand) SetFileSystemPath(fsPath string) {
+	m.args = append(m.args, fsPath)
 }
 
 // SetStdin sets process's standard input

--- a/lepton/mkfs_test.go
+++ b/lepton/mkfs_test.go
@@ -13,11 +13,10 @@ func TestMKFSCommand(t *testing.T) {
 		mkfs.SetFileSystemSize("size")
 		mkfs.SetTargetRoot("targetRoot")
 		mkfs.SetBoot("boot")
-		mkfs.SetImageName("imageName")
+		mkfs.SetEmptyFileSystem()
 
 		got := mkfs.GetArgs()
 		want := []string{
-			"-e",
 			"rawPath",
 			"-s",
 			"size",
@@ -25,7 +24,7 @@ func TestMKFSCommand(t *testing.T) {
 			"targetRoot",
 			"-b",
 			"boot",
-			"imageName",
+			"-e",
 		}
 
 		if !reflect.DeepEqual(got, want) {

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -76,7 +76,6 @@ func (v *Volume) Create(name, data, size, provider string) error {
 	mnf := name + ".manifest"
 
 	rawPath := path.Join(localVolumeDir, raw)
-	mkfsCommand.SetFileSystemPath(rawPath)
 
 	if data != "" {
 		v.config.Dirs = append(v.config.Dirs, data)
@@ -95,9 +94,11 @@ func (v *Volume) Create(name, data, size, provider string) error {
 
 		mkfsCommand.SetStdin(src)
 	} else if size != "" {
+		mkfsCommand.SetEmptyFileSystem()
 		mkfsCommand.SetFileSystemSize(size)
 	}
 
+	mkfsCommand.SetFileSystemPath(rawPath)
 	mkfsCommand.SetupCommand()
 	err := mkfsCommand.Execute()
 	if err != nil {


### PR DESCRIPTION
 * remove -e argument if creating a non-empty volume