### PR TITLE
Fixing 389 and other issues

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -39,7 +39,7 @@ func instanceCreateCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	zone, _ := cmd.Flags().GetString("zone")
-	if zone == "" && (provider == "gcp" || provider == "aws") {
+	if zone != "" && (provider == "gcp" || provider == "aws") {
 		c.CloudConfig.Zone = zone
 	}
 

--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -375,7 +375,7 @@ func (p *AWS) SyncImage(config *Config, target Provider, image string) error {
 func (p *AWS) CreateInstance(ctx *Context) error {
 	result, err := getAWSImages(ctx.config.CloudConfig.Zone)
 	if err != nil {
-		return err
+		exitWithError("Invalid zone")
 	}
 
 	imgName := ctx.config.CloudConfig.ImageName
@@ -472,7 +472,15 @@ func (p *AWS) CreateSG(ctx *Context, svc *ec2.EC2, imgName string) (string, erro
 	if len(result.Vpcs) == 0 {
 		fmt.Println("No VPCs found to associate security group with.")
 	}
-	vpcID := aws.StringValue(result.Vpcs[0].VpcId)
+
+	var vpcID string
+	//TODO: This will fail if there is no default VPC. Need to implement feature where user should be able to mention VPC
+	for i, s := range result.Vpcs {
+		isDefault := *s.IsDefault
+		if isDefault == true {
+			vpcID = aws.StringValue(result.Vpcs[i].VpcId)
+		}
+	}
 
 	t := time.Now().UnixNano()
 	s := strconv.FormatInt(t, 10)
@@ -504,7 +512,7 @@ func (p *AWS) CreateSG(ctx *Context, svc *ec2.EC2, imgName string) (string, erro
 
 	// maybe have these ports specified from config.json in near future
 	_, err = svc.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-		GroupName: aws.String(sgName),
+		GroupId: createRes.GroupId,
 		IpPermissions: []*ec2.IpPermission{
 			(&ec2.IpPermission{}).
 				SetIpProtocol("tcp").

--- a/lepton/utils.go
+++ b/lepton/utils.go
@@ -1,0 +1,11 @@
+package lepton
+
+import (
+	"fmt"
+	"os"
+)
+
+func exitWithError(errs string) {
+	fmt.Println(fmt.Sprintf(ErrorColor, errs))
+	os.Exit(1)
+}


### PR DESCRIPTION
In PR I fixed following problems.

1. CLI wasn't picking up zone as given condition was checking for null value.
2. Added fix for 389 issue now it just shows invalid zone doesn't print complete stack trace. To fix this issue I created separate util.go file for lepton package and added exitWithError function.
3. Previously code was picking up first VPC from multiple VPCs to create SG which is wrong as while creating instance AWS SDK uses default VPC if you don't mention one. So I added code to retrieve default VPC from list. Current code works fine with new account as it contains only default VPC. In future, we should accept VPC from user if not given we can use default one I have added TODo for same in code.