### PR TITLE
Adding support to accept manifest file name in config file

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -119,6 +119,12 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 	c := unWarpConfig(config)
 
 	c.Args = append(c.Args, cmdargs...)
+
+	//Precedance is given to command line manifest file name.
+	if manifestName == "" && c.ManifestName != "" {
+		manifestName = c.ManifestName
+	}
+
 	c.Program = args[0]
 	curdir, _ := os.Getwd()
 	c.ProgramPath = path.Join(curdir, args[0])


### PR DESCRIPTION
Added support to accept manifest file through config file. Right now precedence is given to command line argument. If command line argument is not given manifest value will be populated via config file.