### PR TITLE
Bugfix 672 - invalid region message

### DIFF
--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -244,8 +244,9 @@ func getAWSInstances(region string, filter []*ec2.Filter) []CloudInstance {
 		Filters: filter,
 	}
 	result, err := compute.DescribeInstances(&request)
+
 	if err != nil {
-		fmt.Println(err)
+		exitWithError("invalid region")
 	}
 
 	var cinstances []CloudInstance


### PR DESCRIPTION
Issue - #672

Fixed invalid region message for aws in "ops instance list"