### PR TITLE
Better messaging for image import timeout

### DIFF
--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -1033,7 +1033,11 @@ func (p *AWS) waitSnapshotToBeReady(config *Config, importTaskID *string) (*stri
 			return req, nil
 		},
 	}
-	w.WaitWithContext(ct)
+	err = w.WaitWithContext(ct)
+	if err != nil {
+		fmt.Printf("import timed out after %f minutes\n", time.Since(waitStartTime).Minutes())
+		return nil, err
+	}
 
 	fmt.Printf("import done - took %f minutes\n", time.Since(waitStartTime).Minutes())
 


### PR DESCRIPTION
For some reason an import takes >20 minutes for me.  In this case the error message is very confusing:
```
erik@carbon ~/tmp/nanovm/golang $ ops image create -t aws -c config.json -a hello --show-warnings
Successfully uploaded "hello-image" to "mackdanz-vmimport"
waiting for snapshot - can take like 5min.... 
import done - took 14.981148 minutes
MissingParameter: The request must contain the parameter resourceIdSet
        status code: 400, request id: bc9cfbbf-5497-4aac-b545-ff0a177aac17
```

This change results in a more helpful message:
```
erik@carbon ~/tmp/nanovm/golang $ ops image create -t aws -c config.json -a hello --show-warnings
Successfully uploaded "hello-image" to "mackdanz-vmimport"
waiting for snapshot - can take like 5min.... 
import timed out after 14.970942 minutes
ResourceNotReady: exceeded wait attempts
```