### PR TITLE
Wait longer for AWS image import

### DIFF
--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -1005,7 +1005,7 @@ func (p *AWS) waitSnapshotToBeReady(config *Config, importTaskID *string) (*stri
 	w := request.Waiter{
 		Name:        "DescribeImportSnapshotTasks",
 		Delay:       request.ConstantWaiterDelay(15 * time.Second),
-		MaxAttempts: 60,
+		MaxAttempts: 120,
 		Acceptors: []request.WaiterAcceptor{
 			{
 				State:    request.SuccessWaiterState,


### PR DESCRIPTION
The AWS VM import times out after 15 minutes, but for some reason it requires >20 minutes for me.  Please increase the timeout.