### PR TITLE
Allow set instance name (closes #807)

### DIFF
--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	api "github.com/nanovms/ops/lepton"
 	"github.com/spf13/cobra"
@@ -52,6 +54,15 @@ func instanceCreateCommandHandler(cmd *cobra.Command, args []string) {
 	imagename, _ := cmd.Flags().GetString("imagename")
 	c.CloudConfig.ImageName = imagename
 
+	if len(args) > 0 {
+		c.RunConfig.InstanceName = args[0]
+	} else if c.RunConfig.InstanceName == "" {
+		c.RunConfig.InstanceName = fmt.Sprintf("%v-%v",
+			filepath.Base(c.CloudConfig.ImageName),
+			strconv.FormatInt(time.Now().Unix(), 10),
+		)
+	}
+
 	portsFlag, err := cmd.Flags().GetStringArray("port")
 	if err != nil {
 		panic(err)
@@ -90,7 +101,7 @@ func instanceCreateCommand() *cobra.Command {
 	var imageName, config, flavor, domainname string
 
 	var cmdInstanceCreate = &cobra.Command{
-		Use:   "create",
+		Use:   "create <instance_name>",
 		Short: "create nanos instance",
 		Run:   instanceCreateCommandHandler,
 	}

--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -582,7 +582,7 @@ func (p *AWS) CreateInstance(ctx *Context) error {
 	}
 
 	// Create tags to assign to the instance
-	tags, tagInstanceName := parseToAWSTags(ctx.config.RunConfig.Tags, imgName+"-"+strconv.Itoa(int(time.Now().Unix())))
+	tags, tagInstanceName := parseToAWSTags(ctx.config.RunConfig.Tags, ctx.config.RunConfig.InstanceName)
 
 	// Specify the details of the instance that you want to create.
 	runResult, err := svc.RunInstances(&ec2.RunInstancesInput{

--- a/lepton/azure.go
+++ b/lepton/azure.go
@@ -8,9 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -409,13 +407,6 @@ func (a *Azure) SyncImage(config *Config, target Provider, image string) error {
 }
 
 // CreateInstance - Creates instance on azure Platform
-//
-// this is kind of a pita
-// you have to create the following:
-// {vnet, nsg, subnet, ip, nic} before creating the vm
-//
-// unfortunately this is going to take some serious re-factoring later
-// on w/these massive assumptions being put into place
 func (a *Azure) CreateInstance(ctx *Context) error {
 	username := "fake"
 	password := "fake"
@@ -431,7 +422,7 @@ func (a *Azure) CreateInstance(ctx *Context) error {
 	}
 	location := a.getLocation(ctx.config)
 
-	vmName := ctx.config.CloudConfig.ImageName + strconv.FormatInt(time.Now().Unix(), 10)
+	vmName := ctx.config.RunConfig.InstanceName
 	ctx.logger.Log("spinning up:\t%s\n", vmName)
 
 	// create virtual network

--- a/lepton/config.go
+++ b/lepton/config.go
@@ -71,6 +71,7 @@ type RunConfig struct {
 	ShowErrors     bool
 	ShowDebug      bool
 	Klibs          []string
+	InstanceName   string
 }
 
 // RuntimeConfig constructs runtime config

--- a/lepton/gcp.go
+++ b/lepton/gcp.go
@@ -380,10 +380,6 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 	}
 
 	machineType := fmt.Sprintf("zones/%s/machineTypes/%s", c.CloudConfig.Zone, c.CloudConfig.Flavor)
-	instanceName := fmt.Sprintf("%v-%v",
-		filepath.Base(c.CloudConfig.ImageName),
-		strconv.FormatInt(time.Now().Unix(), 10),
-	)
 
 	imageName := fmt.Sprintf("projects/%v/global/images/%v",
 		c.CloudConfig.ProjectID,
@@ -395,6 +391,8 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 	for _, tag := range ctx.config.RunConfig.Tags {
 		labels[tag.Key] = tag.Value
 	}
+
+	instanceName := c.RunConfig.InstanceName
 
 	rb := &compute.Instance{
 		Name:        instanceName,

--- a/lepton/openstack.go
+++ b/lepton/openstack.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -383,7 +382,7 @@ func (o *OpenStack) CreateInstance(ctx *Context) error {
 
 	fmt.Printf("\nDeploying flavorID %s", flavorID)
 
-	instanceName := imageName + "-" + strconv.FormatInt(time.Now().Unix(), 10)
+	instanceName := ctx.config.RunConfig.InstanceName
 
 	var createOpts servers.CreateOptsBuilder
 	createOpts = &servers.CreateOpts{


### PR DESCRIPTION
* Use command flag or configuration file to set instance name

* Use image name and timestamp to create instance name if not provided

* Update aws, azure, gcp and openstack instance name on creating them