### PR TITLE
pkg list sorting now handles upper- and lowercase

### DIFF
--- a/cmd/package.go
+++ b/cmd/package.go
@@ -63,7 +63,9 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 	for key := range *packages {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
 
 	for _, key := range keys {
 		var row []string


### PR DESCRIPTION
An edge case was found in the previous pkg list sorting where uppercase package names would be sorted above lowercase package names, as found here:
```
$ go run ops.go pkg list
+--------------------+-----------+------------+------------+--------------------------------+
|    PACKAGENAME     |  VERSION  |  LANGUAGE  |  RUNTIME   |          DESCRIPTION           |
+--------------------+-----------+------------+------------+--------------------------------+
| R_3.4.4            | 3.4.4     | R          | R          | R                              |
+--------------------+-----------+------------+------------+--------------------------------+
| bind_9.13.4        | 9.13.4    | c          | bind9      | bind9 - dns resolver           |
+--------------------+-----------+------------+------------+--------------------------------+
| bind_9.16.4        | 9.16.4    | c          | bind9      | bind9 - dns resolver           |
+--------------------+-----------+------------+------------+--------------------------------+
| caddy_1.0.0        | 1.0.0     | go         | caddy      | caddy - a go webserver         |
+--------------------+-----------+------------+------------+--------------------------------+
```

This pull-request solves this issue and sorts the packages, no matter if they start on upper- or lowercase:
```
+--------------------+-----------+------------+------------+--------------------------------+
| python_3.6.7       | 3.6.7     | python3    | python3    |                                |
+--------------------+-----------+------------+------------+--------------------------------+
| R_3.4.4            | 3.4.4     | R          | R          | R                              |
+--------------------+-----------+------------+------------+--------------------------------+
| redis_5.0.5        | 5.0.5     | c          | redis      | in memory k/v store            |
+--------------------+-----------+------------+------------+--------------------------------+
| ruby_2.3.1         | 2.3.1     | ruby       | ruby       |                                |
+--------------------+-----------+------------+------------+--------------------------------+
```