### PR TITLE
Add static IP address to manifest on run command (closes #838)

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/user"
 	"path"
@@ -285,4 +286,13 @@ func prepareNetworkPorts(ports []string) (portsPrepared []string, err error) {
 	}
 
 	return
+}
+
+// isIPAddressValid checks whether IP address is valid
+func isIPAddressValid(ip string) bool {
+	if net.ParseIP(ip) == nil {
+		return false
+	}
+
+	return true
 }

--- a/lepton/config.go
+++ b/lepton/config.go
@@ -56,6 +56,9 @@ type RunConfig struct {
 	Memory         string
 	Bridged        bool
 	TapName        string
+	IPAddr         string
+	Gateway        string
+	NetMask        string
 	Accel          bool
 	UDP            bool // enable UDP
 	UDPPorts       []string

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -299,6 +299,15 @@ func BuildManifest(c *Config) (*Manifest, error) {
 	for _, libpath := range deps {
 		m.AddLibrary(libpath)
 	}
+
+	if c.RunConfig.IPAddr != "" {
+		m.AddNetworkConfig(&ManifestNetworkConfig{
+			IP:      c.RunConfig.IPAddr,
+			Gateway: c.RunConfig.Gateway,
+			NetMask: c.RunConfig.NetMask,
+		})
+	}
+
 	return m, nil
 }
 

--- a/lepton/manifest.go
+++ b/lepton/manifest.go
@@ -16,20 +16,28 @@ type link struct {
 	path string
 }
 
+// ManifestNetworkConfig has network configuration to set static IP
+type ManifestNetworkConfig struct {
+	IP      string
+	Gateway string
+	NetMask string
+}
+
 // Manifest represent the filesystem.
 type Manifest struct {
-	sb          strings.Builder
-	children    map[string]interface{} // root fs
-	boot        map[string]interface{} // boot fs
-	program     string
-	args        []string
-	debugFlags  map[string]rune
-	noTrace     []string
-	environment map[string]string
-	targetRoot  string
-	mounts      map[string]string
-	klibs       []string
-	nightly     bool
+	sb            strings.Builder
+	children      map[string]interface{} // root fs
+	boot          map[string]interface{} // boot fs
+	program       string
+	args          []string
+	debugFlags    map[string]rune
+	noTrace       []string
+	environment   map[string]string
+	targetRoot    string
+	mounts        map[string]string
+	klibs         []string
+	nightly       bool
+	networkConfig *ManifestNetworkConfig
 }
 
 // NewManifest init
@@ -42,6 +50,11 @@ func NewManifest(targetRoot string) *Manifest {
 		targetRoot:  targetRoot,
 		mounts:      make(map[string]string),
 	}
+}
+
+// AddNetworkConfig adds network configuration
+func (m *Manifest) AddNetworkConfig(networkConfig *ManifestNetworkConfig) {
+	m.networkConfig = networkConfig
 }
 
 // AddUserProgram adds user program
@@ -437,6 +450,16 @@ func (m *Manifest) String() string {
 			sb.WriteRune('\n')
 		}
 		sb.WriteString(")\n")
+	}
+
+	if m.networkConfig != nil {
+		sb.WriteString("ipaddr:")
+		sb.WriteString(m.networkConfig.IP)
+		sb.WriteString("\ngateway:")
+		sb.WriteString(m.networkConfig.Gateway)
+		sb.WriteString("\nnetmask:")
+		sb.WriteString(m.networkConfig.NetMask)
+		sb.WriteRune('\n')
 	}
 
 	//


### PR DESCRIPTION
(closes #838)

Users can specify the static IP address using the next command format:
`ops run main -b -t tap0 --ip-address 192.168.42.20 --gateway 192.158.42.255 --netmask 255.255.0.0`

The network configuration parameters are added to the manifest file:
```
...

gateway:192.168.42.1
ipaddr:192.168.42.20
booted:
netmask:255.255.255.0
program:/ops-go-test/main
environment:(OPS_VERSION:NANOS_VERSION:0.1.30 USER:root PWD:/)
arguments:(0:../ops-go-test/main))
```