### PR TITLE
Add support for syscall summary flag in load and run commands

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -175,6 +175,11 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	syscallSummary, err := strconv.ParseBool(cmd.Flag("syscall-summary").Value.String())
+	if err != nil {
+		panic(err)
+	}
+
 	config, _ := cmd.Flags().GetString("config")
 	config = strings.TrimSpace(config)
 	cmdargs, _ := cmd.Flags().GetStringArray("args")
@@ -184,6 +189,10 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 
 	if debugflags {
 		pkgConfig.Debugflags = []string{"trace", "debugsyscalls", "futex_trace", "fault"}
+	}
+
+	if syscallSummary {
+		pkgConfig.Debugflags = append(pkgConfig.Debugflags, "syscall_summary")
 	}
 
 	c = mergeConfigs(pkgConfig, c)
@@ -232,7 +241,7 @@ func LoadCommand() *cobra.Command {
 		ports, args, mounts             []string
 		force, debugflags, verbose      bool
 		nightly, accel, bridged, local  bool
-		skipbuild                       bool
+		skipbuild, syscallSummary       bool
 		config, imageName, manifestName string
 	)
 
@@ -256,6 +265,7 @@ func LoadCommand() *cobra.Command {
 	cmdLoadPackage.PersistentFlags().BoolVarP(&skipbuild, "skipbuild", "s", false, "skip building package image")
 	cmdLoadPackage.PersistentFlags().BoolVarP(&local, "local", "l", false, "load local package")
 	cmdLoadPackage.PersistentFlags().StringArrayVar(&mounts, "mounts", nil, "<volume_id/label>:/<mount_path>")
+	cmdLoadPackage.PersistentFlags().BoolVar(&syscallSummary, "syscall-summary", false, "print syscall summary on exit")
 
 	return cmdLoadPackage
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -143,6 +143,11 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	syscallSummary, err := cmd.Flags().GetBool("syscall-summary")
+	if err != nil {
+		panic(err)
+	}
+
 	c := unWarpConfig(config)
 	AppendGlobalCmdFlagsToConfig(cmd.Flags(), c)
 
@@ -195,6 +200,10 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 		if !api.HasDebuggingSymbols(elfFile) {
 			log.Fatalf("Program %s must be compiled with debugging symbols", c.ProgramPath)
 		}
+	}
+
+	if syscallSummary {
+		c.Debugflags = append(c.Debugflags, "syscall_summary")
 	}
 
 	c.RunConfig.GdbPort = gdbport
@@ -293,6 +302,7 @@ func RunCommand() *cobra.Command {
 	var nightly bool
 	var tap string
 	var mounts []string
+	var syscallSummary bool
 
 	var skipbuild bool
 	var manifestName string
@@ -330,6 +340,7 @@ func RunCommand() *cobra.Command {
 	cmdRun.PersistentFlags().BoolVar(&accel, "accel", true, "use cpu virtualization extension")
 	cmdRun.PersistentFlags().IntVarP(&smp, "smp", "", 1, "number of threads to use")
 	cmdRun.PersistentFlags().StringArrayVar(&mounts, "mounts", nil, "<volume_id/label>:/<mount_path>")
+	cmdRun.PersistentFlags().BoolVar(&syscallSummary, "syscall-summary", false, "print syscall summary on exit")
 
 	return cmdRun
 }


### PR DESCRIPTION
This PR adds a flag to ops to include a manifest symbol that activates an 'strace -c' like summary of syscalls at vm exit to the ops run and load commands.