### PR TITLE
ldd_linux: fix check for dynamically linked executable

### DIFF
--- a/lepton/ldd_linux.go
+++ b/lepton/ldd_linux.go
@@ -38,13 +38,11 @@ func HasDebuggingSymbols(efd *elf.File) bool {
 
 // IsDynamicLinked checks whether elf file was linked dynamically
 func IsDynamicLinked(efd *elf.File) bool {
-	for _, phdr := range efd.Progs {
-		if phdr.Type == elf.PT_DYNAMIC {
-			return true
-		}
+	libs, err := efd.ImportedLibraries()
+	if err != nil || len(libs) == 0 {
+		return false
 	}
-
-	return false
+	return true
 }
 
 // works only on linux, need to


### PR DESCRIPTION
The presence of a dynamic section in an ELF file does not necessarily make the file dynamically linked: a file may have a dynamic section while not having an dependency on shared libraries. The ArangoDB server executable binary for Linux (/usr/sbin/arangod file in https://download.arangodb.com/arangodb37/Community/Linux/arangodb3_3.7.6-1_amd64.deb) is an example of such files.
When a statically linked executable is run with LD_TRACE_LOADED_OBJECTS=1 (as done in the getSharedLibs() method), the dynamic linker executes the binary instead of listing its shared libraries, and this makes getSharedLibs() fail; as a result, "ops run" does not work.

An ELF file is dynamically linked only if it has a dynamic section and this section contains at least one DT_NEEDED entry. The ImportedLibraries() method from the debug/elf Go package can be used to retrieve the list of shared libraries.
This PR changes IsDynamicLinked() to call ImportedLibraries() instead of looking for the dynamic section in the ELF file.