### PR TITLE
Allow to delete old image using a time notation (closes #473)

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,12 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"os"
 	"os/user"
 	"path"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/go-errors/errors"
@@ -295,4 +299,66 @@ func isIPAddressValid(ip string) bool {
 	}
 
 	return true
+}
+
+// posString returns the first index of element in slice.
+// If slice does not contain element, returns -1.
+func posString(slice []string, element string) int {
+	for index, elem := range slice {
+		if elem == element {
+			return index
+		}
+	}
+	return -1
+}
+
+// containsString returns true iff slice contains element
+func containsString(slice []string, element string) bool {
+	return !(posString(slice, element) == -1)
+}
+
+func askForConfirmation() bool {
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	okayResponses := []string{"y", "Y", "yes", "Yes", "YES"}
+	nokayResponses := []string{"n", "N", "no", "No", "NO"}
+	if containsString(okayResponses, response) {
+		return true
+	} else if containsString(nokayResponses, response) {
+		return false
+	} else {
+		fmt.Println("Please type yes or no and then press enter:")
+		return askForConfirmation()
+	}
+}
+
+// SubtractTimeNotation subtracts time notation timestamp from date passed by argument
+func SubtractTimeNotation(date time.Time, notation string) (newDate time.Time, err error) {
+	r := regexp.MustCompile(`(\d+)(d|w|m|y){1}`)
+	groups := r.FindStringSubmatch(notation)
+	if len(groups) == 0 {
+		return newDate, errors.New("invalid time notation")
+	}
+
+	n, err := strconv.Atoi(groups[1])
+	if err != nil {
+		fmt.Println(err)
+		return newDate, err
+	}
+
+	switch groups[2] {
+	case "d":
+		return date.AddDate(0, 0, n*-1), nil
+	case "w":
+		return date.AddDate(0, 0, n*7*-1), nil
+	case "m":
+		return date.AddDate(0, n*-1, 0), nil
+	case "y":
+		return date.AddDate(n*-1, 0, 0), nil
+	default:
+		return date, nil
+	}
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestValidateNetworkPorts(t *testing.T) {
@@ -54,4 +55,80 @@ func TestPrepareNetworkPorts(t *testing.T) {
 
 	})
 
+}
+
+var (
+	ErrInvalidTimeNotation = func(notation string) string {
+		return "expected to throw an error because time notation \"" + notation + "\" is invalid"
+	}
+)
+
+func TestSubtractDateNotation(t *testing.T) {
+	t.Run("should return error if time notation is invalid", func(t *testing.T) {
+		layout := "01/02/2006"
+		str := "01/10/2020"
+		date, _ := time.Parse(layout, str)
+
+		_, err := SubtractTimeNotation(date, "kjfgd")
+		if err == nil {
+			t.Errorf(ErrInvalidTimeNotation("kjfgd"))
+		}
+
+		_, err = SubtractTimeNotation(date, "123")
+		if err == nil {
+			t.Errorf(ErrInvalidTimeNotation("123"))
+		}
+	})
+
+	t.Run("should return date of days ago", func(t *testing.T) {
+		layout := "2006-01-02"
+		str := "2020-10-10"
+		date, _ := time.Parse(layout, str)
+
+		got, _ := SubtractTimeNotation(date, "5d")
+		want := "2020-10-05"
+
+		if want != got.Format(layout) {
+			t.Errorf("got %s, want %s", got.Format(layout), want)
+		}
+	})
+
+	t.Run("should return date of weeks ago", func(t *testing.T) {
+		layout := "2006-01-02"
+		str := "2020-10-10"
+		date, _ := time.Parse(layout, str)
+
+		got, _ := SubtractTimeNotation(date, "5w")
+		want := "2020-09-05"
+
+		if want != got.Format(layout) {
+			t.Errorf("got %s, want %s", got.Format(layout), want)
+		}
+	})
+
+	t.Run("should return date of months ago", func(t *testing.T) {
+		layout := "2006-01-02"
+		str := "2020-10-10"
+		date, _ := time.Parse(layout, str)
+
+		got, _ := SubtractTimeNotation(date, "2m")
+		want := "2020-08-10"
+
+		if want != got.Format(layout) {
+			t.Errorf("got %s, want %s", got.Format(layout), want)
+		}
+	})
+
+	t.Run("should return date of years ago", func(t *testing.T) {
+		layout := "2006-01-02"
+		str := "2020-10-10"
+		date, _ := time.Parse(layout, str)
+
+		got, _ := SubtractTimeNotation(date, "3y")
+		want := "2017-10-10"
+
+		if want != got.Format(layout) {
+			t.Errorf("got %s, want %s", got.Format(layout), want)
+		}
+	})
 }

--- a/lepton/aws.go
+++ b/lepton/aws.go
@@ -104,6 +104,16 @@ func buildAwsTags(configTags []Tag, defaultName string) ([]*ec2.Tag, string) {
 	return tags, name
 }
 
+func (p *AWS) getNameTag(tags []*ec2.Tag) *ec2.Tag {
+	for _, tag := range tags {
+		if *tag.Key == "Name" {
+			return tag
+		}
+	}
+
+	return nil
+}
+
 // GetInstanceByID returns the instance with the id passed by argument if it exists
 func (p *AWS) GetInstanceByID(ctx *Context, id string) (*CloudInstance, error) {
 	var filters []*ec2.Filter

--- a/lepton/aws_image.go
+++ b/lepton/aws_image.go
@@ -173,18 +173,23 @@ func (p *AWS) GetImages(ctx *Context) ([]CloudImage, error) {
 
 	images := result.Images
 	for _, image := range images {
+		tagName := p.getNameTag(image.Tags)
+
 		var name string
-		if image.Tags != nil {
-			name = aws.StringValue(image.Tags[0].Value)
+
+		if tagName != nil {
+			name = *tagName.Value
 		} else {
 			name = "n/a"
 		}
+
+		imageCreatedAt, _ := time.Parse("2006-01-02T15:04:05Z", *image.CreationDate)
 
 		cimage := CloudImage{
 			Name:    name,
 			ID:      *image.Name,
 			Status:  *image.State,
-			Created: *image.CreationDate,
+			Created: imageCreatedAt,
 		}
 
 		cimages = append(cimages, cimage)
@@ -215,7 +220,7 @@ func (p *AWS) ListImages(ctx *Context) error {
 		row = append(row, image.Name)
 		row = append(row, image.ID)
 		row = append(row, image.Status)
-		row = append(row, image.Created)
+		row = append(row, image.Created.String())
 
 		table.Append(row)
 	}

--- a/lepton/aws_image.go
+++ b/lepton/aws_image.go
@@ -220,7 +220,7 @@ func (p *AWS) ListImages(ctx *Context) error {
 		row = append(row, image.Name)
 		row = append(row, image.ID)
 		row = append(row, image.Status)
-		row = append(row, image.Created.String())
+		row = append(row, time2Human(image.Created))
 
 		table.Append(row)
 	}

--- a/lepton/cloud.go
+++ b/lepton/cloud.go
@@ -1,11 +1,15 @@
 package lepton
 
+import "time"
+
 // CloudImage abstracts images for various cloud providers
 type CloudImage struct {
 	ID      string
 	Name    string
 	Status  string
-	Created string // TODO: prob. should be datetime w/helpers for human formatting
+	Size    int64
+	Path    string
+	Created time.Time
 }
 
 // CloudInstance represents the instance that widely use in different

--- a/lepton/digital_ocean_image.go
+++ b/lepton/digital_ocean_image.go
@@ -66,7 +66,7 @@ func (do *DigitalOcean) ListImages(ctx *Context) error {
 		var row []string
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created.String())
+		row = append(row, time2Human(image.Created))
 		table.Append(row)
 	}
 	table.Render()

--- a/lepton/digital_ocean_image.go
+++ b/lepton/digital_ocean_image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/digitalocean/godo"
 	"github.com/olekukonko/tablewriter"
@@ -47,7 +48,7 @@ func (do *DigitalOcean) GetImages(ctx *Context) ([]CloudImage, error) {
 		images[i].ID = fmt.Sprintf("%d", doImage.ID)
 		images[i].Name = doImage.Name
 		images[i].Status = doImage.Status
-		images[i].Created = doImage.Created
+		images[i].Created, _ = time.Parse("2006-01-02T15:04:05Z", doImage.Created)
 	}
 	return images, nil
 }
@@ -65,7 +66,7 @@ func (do *DigitalOcean) ListImages(ctx *Context) error {
 		var row []string
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created)
+		row = append(row, image.Created.String())
 		table.Append(row)
 	}
 	table.Render()

--- a/lepton/digital_ocean_test.go
+++ b/lepton/digital_ocean_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/godo"
 )
@@ -53,9 +54,13 @@ func TestDoGetImages(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	item1CreatedAt, _ := time.Parse("2006-01-02T15:04:05Z", "2020-09-04T06:50:46Z")
+	item2CreatedAt, _ := time.Parse("2006-01-02T15:04:05Z", "2020-09-04T06:50:46Z")
+
 	expectedResult := []CloudImage{
-		{ID: "1", Name: "test1", Status: "test", Created: "2020-09-04T06:50:46Z"},
-		{ID: "2", Name: "test2", Status: "test", Created: "2020-09-04T06:50:46Z"},
+		{ID: "1", Name: "test1", Status: "test", Created: item1CreatedAt},
+		{ID: "2", Name: "test2", Status: "test", Created: item2CreatedAt},
 	}
 	if !reflect.DeepEqual(images, expectedResult) {
 		t.Fail()

--- a/lepton/gcp_image.go
+++ b/lepton/gcp_image.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/oauth2/google"
@@ -122,10 +123,12 @@ func (p *GCloud) GetImages(ctx *Context) ([]CloudImage, error) {
 	err = req.Pages(context, func(page *compute.ImageList) error {
 		for _, image := range page.Items {
 			if val, ok := image.Labels["createdby"]; ok && val == "ops" {
+				imageCreatedAt, _ := time.Parse("2006-01-02T15:04:05-07:00", image.CreationTimestamp)
+
 				ci := CloudImage{
 					Name:    image.Name,
 					Status:  fmt.Sprintf("%v", image.Status),
-					Created: image.CreationTimestamp,
+					Created: imageCreatedAt,
 				}
 
 				images = append(images, ci)
@@ -157,7 +160,7 @@ func (p *GCloud) ListImages(ctx *Context) error {
 		var row []string
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created)
+		row = append(row, image.Created.String())
 		table.Append(row)
 	}
 

--- a/lepton/gcp_image.go
+++ b/lepton/gcp_image.go
@@ -160,7 +160,7 @@ func (p *GCloud) ListImages(ctx *Context) error {
 		var row []string
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created.String())
+		row = append(row, time2Human(image.Created))
 		table.Append(row)
 	}
 

--- a/lepton/onprem_image.go
+++ b/lepton/onprem_image.go
@@ -66,18 +66,12 @@ func (p *OnPrem) GetImages(ctx *Context) (images []CloudImage, err error) {
 		name := info.Name()
 
 		if len(name) > 4 && strings.LastIndex(info.Name(), ".img") == len(name)-4 {
-
 			images = append(images, CloudImage{
 				Name:    info.Name(),
 				Path:    hostpath,
 				Size:    info.Size(),
 				Created: info.ModTime(),
 			})
-			var row []string
-			row = append(row, info.Name())
-			row = append(row, hostpath)
-			row = append(row, bytes2Human(info.Size()))
-			row = append(row, info.ModTime().String())
 		}
 		return nil
 	})
@@ -105,7 +99,7 @@ func (p *OnPrem) ListImages(ctx *Context) error {
 		row = append(row, i.Name)
 		row = append(row, i.Path)
 		row = append(row, bytes2Human(i.Size))
-		row = append(row, i.Created.String())
+		row = append(row, time2Human(i.Created))
 		table.Append(row)
 	}
 	table.Render()

--- a/lepton/openstack_image.go
+++ b/lepton/openstack_image.go
@@ -161,7 +161,7 @@ func (o *OpenStack) GetImages(ctx *Context) ([]CloudImage, error) {
 		cimage := CloudImage{
 			Name:    image.Name,
 			Status:  string(image.Status),
-			Created: time2Human(image.CreatedAt),
+			Created: image.CreatedAt,
 		}
 
 		cimages = append(cimages, cimage)
@@ -191,7 +191,7 @@ func (o *OpenStack) ListImages(ctx *Context) error {
 
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created)
+		row = append(row, image.Created.String())
 
 		table.Append(row)
 	}

--- a/lepton/openstack_image.go
+++ b/lepton/openstack_image.go
@@ -191,7 +191,7 @@ func (o *OpenStack) ListImages(ctx *Context) error {
 
 		row = append(row, image.Name)
 		row = append(row, image.Status)
-		row = append(row, image.Created.String())
+		row = append(row, time2Human(image.Created))
 
 		table.Append(row)
 	}


### PR DESCRIPTION
* Allow to delete more than one image specified on command arguments

* Implement onprem get images method

* Separate concerns of presentation and image getting on onprem provider

* Fix name of aws images list

* Change image cloud "created at" field type