### PR TITLE
Add radar image name env variable (closes #905)

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -87,11 +87,6 @@ func (m *Manifest) AddMount(label, path string) {
 func (m *Manifest) AddEnvironmentVariable(name string, value string) {
 	env := m.root["environment"].(map[string]interface{})
 	env[name] = value
-
-	if name == "RADAR_KEY" {
-		m.AddKlibs([]string{"tls", "radar"})
-	}
-
 }
 
 // AddKlibs append klibs to manifest file if they don't exist

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -274,6 +274,14 @@ func setManifestFromConfig(m *fs.Manifest, c *config.Config) error {
 		m.AddEnvironmentVariable(k, v)
 	}
 
+	if _, hasRadarKey := c.Env["RADAR_KEY"]; hasRadarKey {
+		m.AddKlibs([]string{"tls", "radar"})
+
+		if _, hasRadarImageName := c.Env["RADAR_IMAGE_NAME"]; !hasRadarImageName {
+			m.AddEnvironmentVariable("RADAR_IMAGE_NAME", c.CloudConfig.ImageName)
+		}
+	}
+
 	for k, v := range c.Mounts {
 		m.AddMount(k, v)
 	}


### PR DESCRIPTION
If `RADAR_KEY` env variable is present and `RADAR_IMAGE_NAME` isn't specified ops uses the image name to set the `RADAR_IMAGE_NAME` value.