### PR TITLE
Fix image name used to create an image in openstack 

### DIFF
--- a/cmd/cmd_image.go
+++ b/cmd/cmd_image.go
@@ -63,7 +63,11 @@ func imageCreateCommandHandler(cmd *cobra.Command, args []string) {
 		exitWithError(err.Error())
 	}
 
-	if len(c.CloudConfig.BucketName) == 0 && c.CloudConfig.Platform != "onprem" && c.CloudConfig.Platform != "hyper-v" && c.CloudConfig.Platform != "upcloud" {
+	if len(c.CloudConfig.BucketName) == 0 &&
+		c.CloudConfig.Platform != "onprem" &&
+		c.CloudConfig.Platform != "hyper-v" &&
+		c.CloudConfig.Platform != "upcloud" &&
+		c.CloudConfig.Platform != "openstack" {
 		exitWithError("Please specify a cloud bucket in config")
 	}
 

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -22,7 +22,6 @@ var localImageDir = path.Join(GetOpsHome(), "images")
 // BuildImage builds a unikernel image for user
 // supplied ELF binary.
 func BuildImage(c config.Config) error {
-
 	m, err := BuildManifest(&c)
 	if err != nil {
 		return fmt.Errorf("failed building manifest: %v", err)

--- a/lepton/openstack_image.go
+++ b/lepton/openstack_image.go
@@ -123,7 +123,7 @@ func (o *OpenStack) CreateImage(ctx *Context, imagePath string) error {
 		fmt.Println(err)
 	}
 
-	imagePath = localImageDir + "/" + imgName
+	imagePath = localImageDir + "/" + imgName + ".img"
 	err = o.uploadImage(imagesClient, image.ID, imagePath)
 	if err != nil {
 		return err

--- a/lepton/openstack_instance.go
+++ b/lepton/openstack_instance.go
@@ -37,10 +37,16 @@ func getOpenStackInstances(provider *gophercloud.ProviderClient, opts servers.Li
 
 		for _, s := range serverList {
 			if val, ok := s.Metadata["CreatedBy"]; ok && val == "ops" {
-				// fugly
 				ipv4 := ""
-				// For some instances IP is not assigned.
+
+				// addresses may have a different structure in each cloud provider
+				// vexx
 				z := s.Addresses["public"]
+				if z == nil {
+					// ovh
+					z = s.Addresses["Ext-Net"]
+				}
+
 				if z != nil {
 					for _, v := range z.([]interface{}) {
 						sz := v.(map[string]interface{})
@@ -87,7 +93,7 @@ func (o *OpenStack) CreateInstance(ctx *Context) error {
 		return err
 	}
 
-	fmt.Printf("deploying imageID %s", imageID)
+	fmt.Printf("deploying imageID %s\n", imageID)
 
 	flavorID, err := o.findFlavorByName(ctx.config.CloudConfig.Flavor)
 
@@ -95,7 +101,7 @@ func (o *OpenStack) CreateInstance(ctx *Context) error {
 		fmt.Println(err)
 	}
 
-	fmt.Printf("\nDeploying flavorID %s", flavorID)
+	fmt.Printf("Deploying flavorID %s\n", flavorID)
 
 	instanceName := ctx.config.RunConfig.InstanceName
 
@@ -122,7 +128,7 @@ func (o *OpenStack) CreateInstance(ctx *Context) error {
 		exitWithError(err.Error())
 	}
 
-	fmt.Printf("\nInstance Created Successfully. ID ---> %s | Name ---> %s\n", server.ID, instanceName)
+	fmt.Printf("Instance Created Successfully. ID ---> %s | Name ---> %s\n", server.ID, instanceName)
 
 	if ctx.config.RunConfig.DomainName != "" {
 		pollCount := 60
@@ -251,7 +257,7 @@ func (o *OpenStack) DeleteInstance(ctx *Context, instancename string) error {
 			result := servers.Delete(client, instance.ID).ExtractErr()
 
 			if result == nil {
-				fmt.Printf("Deleted instance with ID %s and name %s", instance.ID, instancename)
+				fmt.Printf("Deleted instance with ID %s and name %s\n", instance.ID, instancename)
 			} else {
 				exitWithError(result.Error())
 			}


### PR DESCRIPTION
(closes #912)

* Fix volumes name display in openstack

* Remove mandatory bucket from openstack cloud providers

* Fix display of IP addresses on listing ovh instances

* Delete image used to create volume in openstack