### PR TITLE
Move keys from RunConfig to CloudConfig

### DIFF
--- a/cmd/cmd_deploy.go
+++ b/cmd/cmd_deploy.go
@@ -93,7 +93,7 @@ func deployCommandHandler(cmd *cobra.Command, args []string) {
 		strconv.FormatInt(time.Now().Unix(), 10),
 	)
 
-	ctx.Config().RunConfig.Tags = append(ctx.Config().RunConfig.Tags, config.Tag{Key: "image", Value: c.CloudConfig.ImageName})
+	ctx.Config().CloudConfig.Tags = append(ctx.Config().CloudConfig.Tags, config.Tag{Key: "image", Value: c.CloudConfig.ImageName})
 
 	err = p.CreateInstance(ctx)
 	if err != nil {

--- a/cmd/flags_create_instance.go
+++ b/cmd/flags_create_instance.go
@@ -16,7 +16,7 @@ type CreateInstanceFlags struct {
 // MergeToConfig append command flags that are used to create an instance
 func (f *CreateInstanceFlags) MergeToConfig(config *config.Config) (err error) {
 	if f.DomainName != "" {
-		config.RunConfig.DomainName = f.DomainName
+		config.CloudConfig.DomainName = f.DomainName
 	}
 
 	if f.Flavor != "" {

--- a/cmd/flags_create_instance_test.go
+++ b/cmd/flags_create_instance_test.go
@@ -43,12 +43,12 @@ func TestCreateInstanceFlagsMergeToConfig(t *testing.T) {
 
 	expected := &config.Config{
 		CloudConfig: config.ProviderConfig{
-			Flavor: "t2",
+			DomainName: "test.nanovms.com",
+			Flavor:     "t2",
 		},
 		RunConfig: config.RunConfig{
-			DomainName: "test.nanovms.com",
-			Ports:      []string{"30", "80", "9000-9040"},
-			UDPPorts:   []string{"90", "50-80", "8000"},
+			Ports:    []string{"30", "80", "9000-9040"},
+			UDPPorts: []string{"90", "50-80", "8000"},
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -174,9 +174,9 @@ type RunConfig struct {
 	// NetMask
 	NetMask string
 
-	// OnPrem is set to be true if the image is in a multi-instance/tenant
-	// on-premise environment.
-	OnPrem bool
+	// Background runs unikernel in background
+	// use onprem instances commands to manage the unikernel
+	Background bool
 
 	// Ports specifies a list of port to expose.
 	Ports []string

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,9 @@ type ProviderConfig struct {
 	// BucketName specifies the bucket to store the ops built image artifacts.
 	BucketName string `cloud:"bucketname"`
 
+	// DomainName
+	DomainName string
+
 	// Flavor
 	Flavor string `cloud:"flavor"`
 
@@ -94,6 +97,18 @@ type ProviderConfig struct {
 	// ProjectID is used to define the project ID when the Platform is set
 	// to gcp.
 	ProjectID string `cloud:"projectid"`
+
+	// SecurityGroup
+	SecurityGroup string
+
+	// Subnet
+	Subnet string
+
+	// Tags
+	Tags []Tag
+
+	// VPC
+	VPC string
 
 	// Zone is used to define the location of the host resource. Lists of these
 	// zones are dependent on selected Platform and can be found here:
@@ -117,9 +132,6 @@ type RunConfig struct {
 	// Accel defines whether hardware acceleration should be enabled.
 	Accel bool
 
-	// BaseName of the image (FIXME).
-	BaseName string
-
 	// Bridged parameter is set to true if bridged networking mode is
 	// in use. This also enables KVM acceleration.
 	Bridged bool
@@ -132,9 +144,6 @@ type RunConfig struct {
 
 	// Debug
 	Debug bool
-
-	// DomainName
-	DomainName string
 
 	// Gateway
 	Gateway string
@@ -172,9 +181,6 @@ type RunConfig struct {
 	// Ports specifies a list of port to expose.
 	Ports []string
 
-	// SecurityGroup
-	SecurityGroup string
-
 	// ShowDebug
 	ShowDebug bool
 
@@ -183,12 +189,6 @@ type RunConfig struct {
 
 	// ShowWarnings
 	ShowWarnings bool
-
-	// Subnet
-	Subnet string
-
-	// Tags
-	Tags []Tag
 
 	// TapName
 	TapName string
@@ -204,9 +204,6 @@ type RunConfig struct {
 
 	// VolumeSizeInGb is an optional parameter only available for OpenStack.
 	VolumeSizeInGb int
-
-	// VPC
-	VPC string
 }
 
 // RuntimeConfig constructs runtime config

--- a/lepton/aws_image.go
+++ b/lepton/aws_image.go
@@ -89,7 +89,7 @@ func (p *AWS) CreateImage(ctx *Context, imagePath string) error {
 	}
 
 	// tag the volume
-	tags, _ := buildAwsTags(c.RunConfig.Tags, key)
+	tags, _ := buildAwsTags(c.CloudConfig.Tags, key)
 
 	ctx.logger.Log("Tagging snapshot")
 	_, err = p.ec2.CreateTags(&ec2.CreateTagsInput{

--- a/lepton/aws_instance.go
+++ b/lepton/aws_instance.go
@@ -226,13 +226,13 @@ func (p *AWS) CreateInstance(ctx *Context) error {
 
 	var sg string
 
-	if ctx.config.RunConfig.SecurityGroup != "" && ctx.config.RunConfig.VPC != "" {
+	if ctx.config.CloudConfig.SecurityGroup != "" && ctx.config.CloudConfig.VPC != "" {
 		err = p.CheckValidSecurityGroup(ctx, svc)
 		if err != nil {
 			return err
 		}
 
-		sg = ctx.config.RunConfig.SecurityGroup
+		sg = ctx.config.CloudConfig.SecurityGroup
 	} else {
 		sg, err = p.CreateSG(ctx, svc, imgName, *vpc.VpcId)
 		if err != nil {
@@ -250,7 +250,7 @@ func (p *AWS) CreateInstance(ctx *Context) error {
 	}
 
 	// Create tags to assign to the instance
-	tags, tagInstanceName := buildAwsTags(ctx.config.RunConfig.Tags, ctx.config.RunConfig.InstanceName)
+	tags, tagInstanceName := buildAwsTags(ctx.config.CloudConfig.Tags, ctx.config.RunConfig.InstanceName)
 
 	instanceInput := &ec2.RunInstancesInput{
 		ImageId:      aws.String(ami),
@@ -278,7 +278,7 @@ func (p *AWS) CreateInstance(ctx *Context) error {
 	fmt.Println("Created instance", *runResult.Instances[0].InstanceId)
 
 	// create dns zones/records to associate DNS record to instance IP
-	if ctx.config.RunConfig.DomainName != "" {
+	if ctx.config.CloudConfig.DomainName != "" {
 		pollCount := 60
 		for pollCount > 0 {
 			fmt.Printf(".")

--- a/lepton/aws_volume.go
+++ b/lepton/aws_volume.go
@@ -64,7 +64,7 @@ func (a *AWS) CreateVolume(ctx *Context, name, data, size, provider string) (Nan
 	}
 
 	// Create tags to assign to the volume
-	tags, _ := buildAwsTags(config.RunConfig.Tags, name)
+	tags, _ := buildAwsTags(config.CloudConfig.Tags, name)
 
 	// Create volume from snapshot
 	createVolumeInput := &ec2.CreateVolumeInput{

--- a/lepton/azure_instance.go
+++ b/lepton/azure_instance.go
@@ -61,7 +61,7 @@ func (a *Azure) CreateInstance(ctx *Context) error {
 
 	// create virtual network
 	var vnet *network.VirtualNetwork
-	configVPC := ctx.config.RunConfig.VPC
+	configVPC := ctx.config.CloudConfig.VPC
 	if configVPC != "" {
 		vnet, err = a.GetVPC(configVPC)
 		if err != nil {
@@ -79,7 +79,7 @@ func (a *Azure) CreateInstance(ctx *Context) error {
 
 	// create nsg
 	var nsg *network.SecurityGroup
-	configSecurityGroup := ctx.config.RunConfig.SecurityGroup
+	configSecurityGroup := ctx.config.CloudConfig.SecurityGroup
 	if configSecurityGroup != "" {
 		nsg, err = a.GetNetworkSecurityGroup(context.TODO(), configSecurityGroup)
 		if err != nil {
@@ -97,7 +97,7 @@ func (a *Azure) CreateInstance(ctx *Context) error {
 
 	// create subnet
 	var subnet *network.Subnet
-	configSubnet := ctx.config.RunConfig.Subnet
+	configSubnet := ctx.config.CloudConfig.Subnet
 	if configSubnet != "" {
 		subnet, err = a.GetVirtualNetworkSubnet(context.TODO(), *vnet.Name, configSubnet)
 		if err != nil {
@@ -214,7 +214,7 @@ func (a *Azure) CreateInstance(ctx *Context) error {
 
 	fmt.Printf("%+v\n", vm)
 
-	if ctx.config.RunConfig.DomainName != "" {
+	if ctx.config.CloudConfig.DomainName != "" {
 		err = CreateDNSRecord(ctx.config, *ip.IPAddress, a)
 		if err != nil {
 			return err

--- a/lepton/gcp_image.go
+++ b/lepton/gcp_image.go
@@ -83,7 +83,7 @@ func (p *GCloud) CreateImage(ctx *Context, imagePath string) error {
 
 	rb := &compute.Image{
 		Name:   c.CloudConfig.ImageName,
-		Labels: buildGcpTags(ctx.config.RunConfig.Tags),
+		Labels: buildGcpTags(ctx.config.CloudConfig.Tags),
 		RawDisk: &compute.ImageRawDisk{
 			Source: sourceURL,
 		},

--- a/lepton/gcp_instance.go
+++ b/lepton/gcp_instance.go
@@ -33,7 +33,7 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 	serialTrue := "true"
 
 	labels := map[string]string{}
-	for _, tag := range ctx.config.RunConfig.Tags {
+	for _, tag := range ctx.config.CloudConfig.Tags {
 		labels[tag.Key] = tag.Value
 	}
 
@@ -61,7 +61,7 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 				},
 			},
 		},
-		Labels: buildGcpTags(ctx.config.RunConfig.Tags),
+		Labels: buildGcpTags(ctx.config.CloudConfig.Tags),
 		Tags: &compute.Tags{
 			Items: []string{instanceName},
 		},
@@ -78,7 +78,7 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 	fmt.Printf("Instance creation succeeded %s.\n", instanceName)
 
 	// create dns zones/records to associate DNS record to instance IP
-	if c.RunConfig.DomainName != "" {
+	if c.CloudConfig.DomainName != "" {
 		instance, err := p.Service.Instances.Get(c.CloudConfig.ProjectID, c.CloudConfig.Zone, instanceName).Do()
 		if err != nil {
 			ctx.logger.Error("failed getting instance")
@@ -88,7 +88,7 @@ func (p *GCloud) CreateInstance(ctx *Context) error {
 		cinstance := p.convertToCloudInstance(instance)
 
 		if len(cinstance.PublicIps) != 0 {
-			ctx.logger.Info("Assigning IP %s to %s", cinstance.PublicIps[0], c.RunConfig.DomainName)
+			ctx.logger.Info("Assigning IP %s to %s", cinstance.PublicIps[0], c.CloudConfig.DomainName)
 			err := CreateDNSRecord(ctx.config, cinstance.PublicIps[0], p)
 			if err != nil {
 				return err

--- a/lepton/gcp_network.go
+++ b/lepton/gcp_network.go
@@ -105,7 +105,7 @@ func (p *GCloud) getNIC(ctx *Context, computeService *compute.Service) (nic []*c
 
 	var network *compute.Network
 
-	vpcName := c.RunConfig.VPC
+	vpcName := c.CloudConfig.VPC
 
 	if vpcName != "" {
 		network, err = p.findOrCreateVPC(ctx, computeService, vpcName)
@@ -114,7 +114,7 @@ func (p *GCloud) getNIC(ctx *Context, computeService *compute.Service) (nic []*c
 		}
 
 		var subnet *compute.Subnetwork
-		subnetName := c.RunConfig.Subnet
+		subnetName := c.CloudConfig.Subnet
 
 		if subnetName != "" {
 			regionParts := strings.Split(c.CloudConfig.Zone, "-")

--- a/lepton/onprem_instance.go
+++ b/lepton/onprem_instance.go
@@ -35,7 +35,7 @@ func (p *OnPrem) CreateInstance(ctx *Context) error {
 	imgpath := path.Join(opshome, "images", c.CloudConfig.ImageName)
 
 	c.RunConfig.Imagename = imgpath
-	c.RunConfig.OnPrem = true
+	c.RunConfig.Background = true
 
 	err := hypervisor.Start(&c.RunConfig)
 	if err != nil {

--- a/lepton/onprem_instance.go
+++ b/lepton/onprem_instance.go
@@ -25,18 +25,15 @@ func (p *OnPrem) CreateInstance(ctx *Context) error {
 		os.Exit(1)
 	}
 
-	instancename := c.RunConfig.InstanceName
-
-	if instancename == "" {
-		instancename = c.CloudConfig.ImageName
+	if c.RunConfig.InstanceName == "" {
+		c.RunConfig.InstanceName = c.CloudConfig.ImageName
 	}
 
-	fmt.Printf("booting %s ...\n", instancename)
+	fmt.Printf("booting %s ...\n", c.RunConfig.InstanceName)
 
 	opshome := GetOpsHome()
 	imgpath := path.Join(opshome, "images", c.CloudConfig.ImageName)
 
-	c.RunConfig.BaseName = instancename
 	c.RunConfig.Imagename = imgpath
 	c.RunConfig.OnPrem = true
 

--- a/lepton/openstack_instance.go
+++ b/lepton/openstack_instance.go
@@ -130,7 +130,7 @@ func (o *OpenStack) CreateInstance(ctx *Context) error {
 
 	fmt.Printf("Instance Created Successfully. ID ---> %s | Name ---> %s\n", server.ID, instanceName)
 
-	if ctx.config.RunConfig.DomainName != "" {
+	if ctx.config.CloudConfig.DomainName != "" {
 		pollCount := 60
 		for pollCount > 0 {
 			fmt.Printf(".")

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -76,7 +76,7 @@ type DNSService interface {
 
 // CreateDNSRecord does the necessary operations to create a DNS record without issues in an cloud provider
 func CreateDNSRecord(config *config.Config, aRecordIP string, dnsService DNSService) error {
-	domainName := config.RunConfig.DomainName
+	domainName := config.CloudConfig.DomainName
 	if err := isDomainValid(domainName); err != nil {
 		return err
 	}

--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -81,7 +81,7 @@ func (q *qemu) Start(rconfig *config.RunConfig) error {
 		q.cmd.Stderr = os.Stderr
 	}
 
-	if rconfig.OnPrem {
+	if rconfig.Background {
 		err := q.cmd.Start()
 		if err != nil {
 			fmt.Println(err)
@@ -327,7 +327,7 @@ func (q *qemu) setConfig(rconfig *config.RunConfig) {
 	q.addNetDevice(netDevType, ifaceName, "", rconfig.Ports, rconfig.UDP)
 	q.addDisplay("none")
 
-	if rconfig.OnPrem {
+	if rconfig.Background {
 		q.addSerial("file:/tmp/" + rconfig.InstanceName + ".log")
 	} else {
 		q.addSerial("stdio")

--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -328,7 +328,7 @@ func (q *qemu) setConfig(rconfig *config.RunConfig) {
 	q.addDisplay("none")
 
 	if rconfig.OnPrem {
-		q.addSerial("file:/tmp/" + rconfig.BaseName + ".log")
+		q.addSerial("file:/tmp/" + rconfig.InstanceName + ".log")
 	} else {
 		q.addSerial("stdio")
 	}


### PR DESCRIPTION
closes #916 

* Once DomainName, SecurityGroup, Subnet, Tags and VPC are only used on cloud providers it makes more sense to have them on CloudConfig than in RunConfig.

* BaseName was deprecated in favor of the key InstanceName