### PR TITLE
Set onprem volume flag size

### DIFF
--- a/cmd/cmd_image_test.go
+++ b/cmd/cmd_image_test.go
@@ -14,7 +14,7 @@ func TestCreateImage(t *testing.T) {
 
 	createImageCmd := cmd.ImageCommands()
 
-	createImageCmd.SetArgs([]string{"create", "-a", basicProgram})
+	createImageCmd.SetArgs([]string{"create", basicProgram})
 
 	err := createImageCmd.Execute()
 

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -229,7 +229,6 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	if !runLocalInstanceFlags.SkipBuild {
-		setNanosBaseImage(c)
 		if err = api.BuildImageFromPackage(pkgFlags.PackagePath(), *c); err != nil {
 			panic(err)
 		}

--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -46,12 +46,6 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 
 	setNanosBaseImage(c)
 
-	if len(flags.CmdArgs) != 0 {
-		c.Program = flags.CmdArgs[0]
-	} else if len(c.Args) != 0 {
-		c.Program = c.Args[0]
-	}
-
 	if c.RunConfig.Imagename == "" && c.Program != "" {
 		c.RunConfig.Imagename = c.Program
 	}

--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -134,3 +134,17 @@ func PersistBuildImageCommandFlags(cmdFlags *pflag.FlagSet) {
 	cmdFlags.StringArray("mounts", nil, "mount <volume_id:mount_path>")
 	cmdFlags.StringArrayP("args", "a", nil, "command line arguments")
 }
+
+func setNanosBaseImage(c *types.Config) {
+	var err error
+	var currversion string
+
+	if c.NightlyBuild {
+		currversion, err = downloadNightlyImages(c)
+	} else {
+		currversion, err = getCurrentVersion()
+	}
+
+	panicOnError(err)
+	updateNanosToolsPaths(c, currversion)
+}

--- a/cmd/flags_build_image_test.go
+++ b/cmd/flags_build_image_test.go
@@ -63,7 +63,7 @@ func TestBuildImageFlagsMergeToConfig(t *testing.T) {
 			Imagename: imagesPath + "/test-image.img",
 		},
 		Args:       []string{"a b c d"},
-		Program:    "a b c d",
+		Program:    "",
 		TargetRoot: "unix",
 		Env:        map[string]string{"test": "1234"},
 		NameServer: "8.8.8.8",

--- a/cmd/flags_nightly.go
+++ b/cmd/flags_nightly.go
@@ -53,20 +53,6 @@ func PersistNightlyCommandFlags(cmdFlags *pflag.FlagSet) {
 	cmdFlags.BoolP("nightly", "n", false, "nightly build")
 }
 
-func setNanosBaseImage(c *types.Config) {
-	var err error
-	var currversion string
-
-	if c.NightlyBuild {
-		currversion, err = downloadNightlyImages(c)
-	} else {
-		currversion, err = getCurrentVersion()
-	}
-
-	panicOnError(err)
-	updateNanosToolsPaths(c, currversion)
-}
-
 func updateNanosToolsPaths(c *types.Config, version string) {
 	if c.NightlyBuild {
 		version = "nightly"

--- a/cmd/flags_pkg.go
+++ b/cmd/flags_pkg.go
@@ -93,6 +93,9 @@ func (flags *PkgCommandFlags) MergeToConfig(c *types.Config) (err error) {
 		c.CloudConfig.ImageName = imageName
 		imageName = path.Join(images, filepath.Base(imageName))
 	}
+	if c.Mounts != nil {
+		pkgConfig.Mounts = c.Mounts
+	}
 
 	*c = *pkgConfig
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -78,7 +78,7 @@ func buildImage(imageName string) string {
 
 	createImageCmd := cmd.ImageCommands()
 
-	createImageCmd.SetArgs([]string{"create", "-a", basicProgram, "-i", imageName})
+	createImageCmd.SetArgs([]string{"create", basicProgram, "-i", imageName})
 
 	createImageCmd.Execute()
 

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -62,8 +62,11 @@ func CreateLocalVolume(config *types.Config, name, data, size, provider string) 
 	tmp := fmt.Sprintf("%s.raw", name)
 	tmpPath := path.Join(config.BuildDir, tmp)
 	mkfsCommand.SetFileSystemPath(tmpPath)
-	if config.BaseVolumeSz != "" {
+
+	if config.BaseVolumeSz != "" && size == "" {
 		mkfsCommand.SetFileSystemSize(config.BaseVolumeSz)
+	} else if size != "" {
+		mkfsCommand.SetFileSystemSize(size)
 	}
 
 	err := mkfsCommand.Execute()


### PR DESCRIPTION
Although the flag was setup in command we weren't using the flag value to change the volume size.

Also, pkg load command was setting 2 times the nanos tools paths in the configuration file.