### PR TITLE
Download nanos when version directory doesn't exist

### DIFF
--- a/cmd/cmd_update.go
+++ b/cmd/cmd_update.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"runtime"
 
 	api "github.com/nanovms/ops/lepton"
@@ -28,7 +29,8 @@ func updateCommandHandler(cmd *cobra.Command, args []string) {
 		fmt.Println("Updates ops to latest release.")
 	}
 	local, remote := api.LocalReleaseVersion, api.LatestReleaseVersion
-	if local == "0.0" || parseVersion(local, 4) != parseVersion(remote, 4) {
+	_, err = os.Stat(path.Join(api.GetOpsHome(), local))
+	if local == "0.0" || parseVersion(local, 4) != parseVersion(remote, 4) || os.IsNotExist(err) {
 		err = api.DownloadReleaseImages(remote)
 		if err != nil {
 			fmt.Println(err)


### PR DESCRIPTION
To use custom nanos build, user overwrites files in `~/.ops/0.1.xx` directory. To go back to stock install, if user then deletes `~/.ops/0.1.xx` directory and executes `ops update` command, it does not re-create that directory (unless `~/.ops/latest.txt` file is also deleted).

PR adds a check for directory existence.