### PR TITLE
Use basename for CloudConfig.ImageName

### DIFF
--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -51,7 +51,7 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 	}
 
 	if c.RunConfig.Imagename != "" {
-		imageName := strings.Split(c.RunConfig.Imagename, ".")[0]
+		imageName := strings.Split(path.Base(c.RunConfig.Imagename), ".")[0]
 		if imageName == "" {
 			imageName = lepton.GenerateImageName(filepath.Base(c.Program))
 			c.CloudConfig.ImageName = fmt.Sprintf("%v-image", filepath.Base(c.Program))


### PR DESCRIPTION
#### Setup

```sh
$ mkdir -p test/foo.bar/publish/
$ cp myApp test/foo.bar/publish/
$ ops build test/foo.bar/publish/myApp -t hyper-v
```

#### Master
> Bootable image file:/home/am11/.ops/vhdx-images/foo.vhdx

#### PR
> Bootable image file:/home/am11/.ops/vhdx-images/myApp.vhdx