### PR TITLE
use a local package when specified (closes #943)

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -138,11 +138,11 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 }
 
 func cmdGetPackage(cmd *cobra.Command, args []string) {
-	downloadAndExtractPackage(args[0])
+	downloadLocalPackage(args[0])
 }
 
 func cmdPackageDescribe(cmd *cobra.Command, args []string) {
-	expackage := downloadAndExtractPackage(args[0])
+	expackage := downloadPackage(args[0])
 
 	description := path.Join(expackage, "README.md")
 	if _, err := os.Stat(description); err != nil {
@@ -170,7 +170,7 @@ func cmdPackageDescribe(cmd *cobra.Command, args []string) {
 }
 
 func cmdPackageContents(cmd *cobra.Command, args []string) {
-	expackage := downloadAndExtractPackage(args[0])
+	expackage := downloadPackage(args[0])
 
 	filepath.Walk(expackage, func(hostpath string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -199,11 +199,13 @@ func LoadCommand() *cobra.Command {
 		Run:   loadCommandHandler,
 	}
 
-	PersistConfigCommandFlags(cmdLoadPackage.PersistentFlags())
-	PersistBuildImageCommandFlags(cmdLoadPackage.PersistentFlags())
-	PersistRunLocalInstanceCommandFlags(cmdLoadPackage.PersistentFlags())
-	PersistNightlyCommandFlags(cmdLoadPackage.PersistentFlags())
-	cmdLoadPackage.PersistentFlags().BoolP("local", "l", false, "load local package")
+	persistentFlags := cmdLoadPackage.PersistentFlags()
+
+	PersistConfigCommandFlags(persistentFlags)
+	PersistBuildImageCommandFlags(persistentFlags)
+	PersistRunLocalInstanceCommandFlags(persistentFlags)
+	PersistNightlyCommandFlags(persistentFlags)
+	persistentFlags.BoolP("local", "l", false, "load local package")
 
 	return cmdLoadPackage
 }

--- a/cmd/download_package.go
+++ b/cmd/download_package.go
@@ -8,28 +8,37 @@ import (
 	api "github.com/nanovms/ops/lepton"
 )
 
-func downloadAndExtractPackage(pkg string) string {
-	packagePath := api.GetOpsHome() + "/local_packages/" + pkg
+func downloadLocalPackage(pkg string) string {
+	packagesDirPath := path.Join(api.GetOpsHome(), "local_packages")
+	return downloadAndExtractPackage(packagesDirPath, pkg)
+}
 
-	if _, err := os.Stat(packagePath); err == nil {
-		return packagePath
-	}
+func downloadPackage(pkg string) string {
+	packagesDirPath := path.Join(api.GetOpsHome(), "packages")
+	return downloadAndExtractPackage(packagesDirPath, pkg)
+}
 
-	localPackagesPath := path.Join(api.GetOpsHome(), "local_packages")
-	err := os.MkdirAll(localPackagesPath, 0755)
+func downloadAndExtractPackage(packagesDirPath, pkg string) string {
+	err := os.MkdirAll(packagesDirPath, 0755)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	expackage := path.Join(localPackagesPath, pkg)
+	expackage := path.Join(packagesDirPath, pkg)
 	opsPackage, err := api.DownloadPackage(pkg)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	api.ExtractPackage(opsPackage, localPackagesPath)
+	api.ExtractPackage(opsPackage, packagesDirPath)
+
+	err = os.Remove(opsPackage)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	return expackage
 }


### PR DESCRIPTION
* store package files in local_packages on using ops pkg get

* if package does not exist in ~/.ops/packages downloads it

* if local package does not exist displays error message

* Remove package tar file after extracting