### PR TITLE
De-duplicate ports 

### DIFF
--- a/cmd/flags_run_local_instance.go
+++ b/cmd/flags_run_local_instance.go
@@ -133,9 +133,20 @@ func (flags *RunLocalInstanceCommandFlags) MergeToConfig(c *types.Config) (err e
 			errstr := fmt.Sprintf("Port %d is forwarded and cannot be used as gdb port", flags.GDBPort)
 			return errors.New(errstr)
 		}
-	}
 
-	c.RunConfig.Ports = append(c.RunConfig.Ports, ports...)
+		portAlreadyExists := false
+		for _, rconfigPort := range c.RunConfig.Ports {
+			if rconfigPort == p {
+				portAlreadyExists = true
+				break
+			}
+		}
+
+		if !portAlreadyExists {
+			c.RunConfig.Ports = append(c.RunConfig.Ports, p)
+		}
+
+	}
 
 	return
 }


### PR DESCRIPTION
if the same port is specified in the command flag and in the configuration file do not append duplicated port to configuration (closes #961)