### PR TITLE
Remove default gateway/netmask handling from ops

### DIFF
--- a/cmd/flags_run_local_instance_test.go
+++ b/cmd/flags_run_local_instance_test.go
@@ -93,9 +93,10 @@ func TestRunLocalInstanceFlagsMergeToConfig(t *testing.T) {
 		expected := &types.Config{
 			Debugflags: []string{},
 			RunConfig: types.RunConfig{
-				Accel: true,
-				CPUs:  1,
-				Ports: []string{"80", "90", "81", "82-85"},
+				Accel:   true,
+				CPUs:    1,
+				Ports:   []string{"80", "90", "81", "82-85"},
+				NetMask: "255.255.255.0",
 			},
 		}
 


### PR DESCRIPTION
Defaults are now set by nanos, so it works consistently across `ops run`, `ops instance create` and other similar commands.