### PR TITLE
Package docs: fix environment variables and shasum command line

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -23,7 +23,7 @@ following:
 export PKGNAME=lua
 export PKGVERSION=5.2.4
 
-mkdir $PKGNAME_$PKGVERSION
+mkdir "$PKGNAME"_"$PKGVERSION"
 ```
 
 ### Populate it
@@ -88,7 +88,7 @@ using libc which will be necessary for ordinary applications.
 The name needs to reflect this format:
 
 ```
-tar czf $PKGNAME_PKGVERSION.tar.gz $PKGNAME_$PKGVERSION
+tar czf "$PKGNAME"_"$PKGVERSION".tar.gz "$PKGNAME"_"$PKGVERSION"
 ```
 
 ### Update the manifest.json
@@ -100,7 +100,7 @@ gsutil cp gs://packagehub/manifest.json .
 ```
 
 ```
-shasum -a 256 "$PKG_NAME"_"$PKGVERSION"
+shasum -a 256 "$PKGNAME"_"$PKGVERSION".tar.gz
 ```
 
 ```


### PR DESCRIPTION
References to environment variables should be under double quotes, and the SHA checksum needs to be calculated on the tar.gz file instead of the uncompressed package folder.