### PR TITLE
Truncate existing files when extracting from an archive

### DIFF
--- a/lepton/package.go
+++ b/lepton/package.go
@@ -223,7 +223,9 @@ func ExtractPackage(archive string, dest string) {
 			if err != nil {
 				panic(err)
 			}
-
+			if err := f.Truncate(0); err != nil {
+				panic(err)
+			}
 			if _, err := io.Copy(f, tr); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
When extracting from an archive to a directory that already contains a file with the same name, if the archive file
is shorter, then the bytes are just copied into the existing file without changing the length. This fix truncates existing files when extracting from an archive to accurately extract shorter files. This problem can manifest
is strange ways with nightly builds, most recently with nanos kernel images becoming significantly smaller than
they were before.