### PR TITLE
Expose cloud provider factory

### DIFF
--- a/cmd/cmd_image.go
+++ b/cmd/cmd_image.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/provider"
 	"github.com/nanovms/ops/types"
 	"github.com/spf13/cobra"
 )
@@ -293,8 +294,8 @@ func imageResizeCommandHandler(cmd *cobra.Command, args []string) {
 		c.CloudConfig.Zone = zone
 	}
 
-	provider, _ := cmd.Flags().GetString("target-cloud")
-	p, err := getCloudProvider(provider, &c.CloudConfig)
+	targetCloud, _ := cmd.Flags().GetString("target-cloud")
+	p, err := provider.CloudProvider(targetCloud, &c.CloudConfig)
 	if err != nil {
 		exitWithError(err.Error())
 	}
@@ -344,13 +345,13 @@ func imageSyncCommandHandler(cmd *cobra.Command, args []string) {
 		conf.CloudConfig.Zone = zone
 	}
 
-	src, err := getCloudProvider(source, &conf.CloudConfig)
+	src, err := provider.CloudProvider(source, &conf.CloudConfig)
 	if err != nil {
 		exitWithError(err.Error())
 	}
 
 	target, _ := cmd.Flags().GetString("target-cloud")
-	tar, err := getCloudProvider(target, &conf.CloudConfig)
+	tar, err := provider.CloudProvider(target, &conf.CloudConfig)
 	if err != nil {
 		exitWithError(err.Error())
 	}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -1,63 +1,13 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/nanovms/ops/aws"
-	"github.com/nanovms/ops/azure"
-	"github.com/nanovms/ops/digitalocean"
-	"github.com/nanovms/ops/gcp"
-	"github.com/nanovms/ops/hyperv"
 	api "github.com/nanovms/ops/lepton"
-	"github.com/nanovms/ops/oci"
-	"github.com/nanovms/ops/onprem"
-	"github.com/nanovms/ops/openstack"
+	"github.com/nanovms/ops/provider"
 	"github.com/nanovms/ops/types"
-	"github.com/nanovms/ops/upcloud"
-	"github.com/nanovms/ops/vbox"
-	"github.com/nanovms/ops/vsphere"
-	"github.com/nanovms/ops/vultr"
 )
 
-// TODO : use factory or DI
-func getCloudProvider(providerName string, c *types.ProviderConfig) (api.Provider, error) {
-	var provider api.Provider
-
-	switch providerName {
-	case "gcp":
-		provider = gcp.NewGCloud()
-	case "onprem":
-		provider = &onprem.OnPrem{}
-	case "aws":
-		provider = &aws.AWS{}
-	case "do":
-		provider = &digitalocean.DigitalOcean{}
-	case "vultr":
-		provider = &vultr.Vultr{}
-	case "vsphere":
-		provider = &vsphere.Vsphere{}
-	case "openstack":
-		provider = &openstack.OpenStack{}
-	case "azure":
-		provider = &azure.Azure{}
-	case "hyper-v":
-		provider = hyperv.NewProvider()
-	case "upcloud":
-		provider = upcloud.NewProvider()
-	case "oci":
-		provider = oci.NewProvider()
-	case "vbox":
-		provider = vbox.NewProvider()
-	default:
-		return provider, fmt.Errorf("error:Unknown provider %s", providerName)
-	}
-
-	err := provider.Initialize(c)
-	return provider, err
-}
-
 func getProviderAndContext(c *types.Config, providerName string) (api.Provider, *api.Context, error) {
-	p, err := getCloudProvider(providerName, &c.CloudConfig)
+	p, err := provider.CloudProvider(providerName, &c.CloudConfig)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/nanovms/ops/aws"
+	"github.com/nanovms/ops/azure"
+	"github.com/nanovms/ops/digitalocean"
+	"github.com/nanovms/ops/gcp"
+	"github.com/nanovms/ops/hyperv"
+	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/oci"
+	"github.com/nanovms/ops/onprem"
+	"github.com/nanovms/ops/openstack"
+	"github.com/nanovms/ops/types"
+	"github.com/nanovms/ops/upcloud"
+	"github.com/nanovms/ops/vbox"
+	"github.com/nanovms/ops/vsphere"
+	"github.com/nanovms/ops/vultr"
+)
+
+func CloudProvider(providerName string, c *types.ProviderConfig) (lepton.Provider, error) {
+	var provider lepton.Provider
+
+	switch providerName {
+	case "gcp":
+		provider = gcp.NewGCloud()
+	case "onprem":
+		provider = &onprem.OnPrem{}
+	case "aws":
+		provider = &aws.AWS{}
+	case "do":
+		provider = &digitalocean.DigitalOcean{}
+	case "vultr":
+		provider = &vultr.Vultr{}
+	case "vsphere":
+		provider = &vsphere.Vsphere{}
+	case "openstack":
+		provider = &openstack.OpenStack{}
+	case "azure":
+		provider = &azure.Azure{}
+	case "hyper-v":
+		provider = hyperv.NewProvider()
+	case "upcloud":
+		provider = upcloud.NewProvider()
+	case "oci":
+		provider = oci.NewProvider()
+	case "vbox":
+		provider = vbox.NewProvider()
+	default:
+		return provider, fmt.Errorf("error:Unknown provider %s", providerName)
+	}
+
+	err := provider.Initialize(c)
+	return provider, err
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nanovms/ops/vultr"
 )
 
+// CloudProvider is a factory that returns an existing provider based on provider type passed by argument
 func CloudProvider(providerName string, c *types.ProviderConfig) (lepton.Provider, error) {
 	var provider lepton.Provider
 


### PR DESCRIPTION
External libraries can use the cloud provider factory to easily get a specific cloud provider.