### PR TITLE
Add ability to pass options from json directly to manifest

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -358,6 +358,10 @@ func (m *Manifest) AddLibrary(path string) {
 	m.AddFileTo(node, parts[len(parts)-1], path)
 }
 
+func (m *Manifest) AddPassthrough(key, value string) {
+	m.root[key] = value
+}
+
 func (m *Manifest) finalize() {
 	if m.boot != nil {
 		klibDir, isDir := m.bootDir()["klib"].(map[string]interface{})

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -358,6 +358,7 @@ func (m *Manifest) AddLibrary(path string) {
 	m.AddFileTo(node, parts[len(parts)-1], path)
 }
 
+// AddPassthrough to add key, value directly to manifest
 func (m *Manifest) AddPassthrough(key, value string) {
 	m.root[key] = value
 }

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -330,6 +330,10 @@ func BuildManifest(c *types.Config) (*fs.Manifest, error) {
 		})
 	}
 
+	for k, v := range c.ManifestPassthrough {
+		m.AddPassthrough(k, v)
+	}
+
 	return m, nil
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	// NoTrace
 	NoTrace []string
 
+	// Straight passthrough of options to manifest
+	ManifestPassthrough map[string]string
+
 	// Program
 	Program string
 


### PR DESCRIPTION
This adds a new section for config.json, "ManifestPassthrough", that takes the key/value pairs from that section
and inserts them directly into the manifest without validation or processing. Intended to be undocumented
for use with debugging or bleeding edge nanos options.
