### PR TITLE
Add port env var (closes #1014)

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -298,6 +298,10 @@ func setManifestFromConfig(m *fs.Manifest, c *types.Config) error {
 		})
 	}
 
+	if len(c.RunConfig.Ports) != 0 {
+		m.AddEnvironmentVariable("OPS_PORT", strings.Join(c.RunConfig.Ports, ","))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* If a port is defined in the configuration or in the flag, the env var "OPS_PORT" with the port value is added to nanos image