### PR TITLE
aarch64: default to gic v2 and kernel.img in CWD

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -326,9 +326,9 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) {
 	} else {
 		q.addOption("-machine", "virt")
 
-		q.addOption("-machine", "gic-version=3")
+		q.addOption("-machine", "gic-version=2")
 		q.addOption("-machine", "highmem=off")
-		q.addOption("-kernel", "/home/ubuntu/.ops/0.1.31/kernel.img")
+		q.addOption("-kernel", "./kernel.img")
 
 		q.addOption("-device", "virtio-blk-pci,drive=hd0")
 


### PR DESCRIPTION
In the workaround to allow building images for aarch64 / virt platform, default to using GICv2 and locating kernel.img in the current working directory.
