### PR TITLE
Prevent 'pkg describe' to redownload existing package

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -171,7 +171,10 @@ func cmdPackageDescribe(cmd *cobra.Command, args []string) {
 }
 
 func cmdPackageContents(cmd *cobra.Command, args []string) {
-	expackage := downloadPackage(args[0])
+	expackage := filepath.Join(packageDirectoryPath(), args[0])
+	if _, err := os.Stat(expackage); os.IsNotExist(err) {
+		expackage = downloadPackage(args[0])
+	}
 
 	filepath.Walk(expackage, func(hostpath string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -142,7 +142,10 @@ func cmdGetPackage(cmd *cobra.Command, args []string) {
 }
 
 func cmdPackageDescribe(cmd *cobra.Command, args []string) {
-	expackage := downloadPackage(args[0])
+	expackage := filepath.Join(packageDirectoryPath(), args[0])
+	if _, err := os.Stat(expackage); os.IsNotExist(err) {
+		expackage = downloadPackage(args[0])
+	}
 
 	description := path.Join(expackage, "README.md")
 	if _, err := os.Stat(description); err != nil {

--- a/cmd/download_package.go
+++ b/cmd/download_package.go
@@ -13,9 +13,12 @@ func downloadLocalPackage(pkg string) string {
 	return downloadAndExtractPackage(packagesDirPath, pkg)
 }
 
+func packageDirectoryPath() string {
+	return path.Join(api.GetOpsHome(), "packages")
+}
+
 func downloadPackage(pkg string) string {
-	packagesDirPath := path.Join(api.GetOpsHome(), "packages")
-	return downloadAndExtractPackage(packagesDirPath, pkg)
+	return downloadAndExtractPackage(packageDirectoryPath(), pkg)
 }
 
 func downloadAndExtractPackage(packagesDirPath, pkg string) string {

--- a/upcloud/upcloud.go
+++ b/upcloud/upcloud.go
@@ -49,9 +49,12 @@ func (p *Provider) Initialize(c *types.ProviderConfig) error {
 		return errors.New(`"UPCLOUD_PASSWORD" not set`)
 	}
 
-	p.zone = os.Getenv("UPCLOUD_ZONE")
+	p.zone = c.Zone
 	if p.zone == "" {
-		return errors.New(`"UPCLOUD_ZONE" not set`)
+		p.zone = os.Getenv("UPCLOUD_ZONE")
+		if p.zone == "" {
+			return errors.New(`"UPCLOUD_ZONE" not set`)
+		}
 	}
 
 	if p.upcloud == nil {


### PR DESCRIPTION
Added checking for existing package first before deciding to download it.