### PR TITLE
Packages: add support for symlinks

### DIFF
--- a/lepton/package.go
+++ b/lepton/package.go
@@ -228,6 +228,10 @@ func ExtractPackage(archive string, dest string) {
 				panic(err)
 			}
 			f.Close()
+		case tar.TypeSymlink:
+			if err := os.Symlink(header.Linkname, target); err != nil {
+				log.Warn(err.Error())
+			}
 		}
 	}
 }


### PR DESCRIPTION
With this change, Ops can load packages containing symbolic links.