### PR TITLE
create local packages directory if it does not exist in flags pkg tests

### DIFF
--- a/lepton/const.go
+++ b/lepton/const.go
@@ -62,6 +62,8 @@ func GetOpsHome() string {
 	instances := path.Join(opshome, "instances")
 	manifests := path.Join(opshome, "manifests")
 	volumes := path.Join(opshome, "volumes")
+	localPackages := path.Join(opshome, "local_packages")
+	packages := path.Join(opshome, "packages")
 
 	if _, err := os.Stat(images); os.IsNotExist(err) {
 		os.MkdirAll(images, 0755)
@@ -77,6 +79,14 @@ func GetOpsHome() string {
 
 	if _, err := os.Stat(volumes); os.IsNotExist(err) {
 		os.MkdirAll(volumes, 0755)
+	}
+
+	if _, err := os.Stat(localPackages); os.IsNotExist(err) {
+		os.MkdirAll(localPackages, 0755)
+	}
+
+	if _, err := os.Stat(packages); os.IsNotExist(err) {
+		os.MkdirAll(packages, 0755)
 	}
 
 	return opshome


### PR DESCRIPTION
The broken test isn't related to the code changes. The `local_packages` directory doesn't exist at the moment that the test is running in circleci.