### PR TITLE
Check if one or more argument failed to be set

### DIFF
--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
+	"github.com/go-errors/errors"
 	"github.com/nanovms/ops/log"
 	"github.com/nanovms/ops/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // GetRootCommand provides set all commands for Ops
@@ -14,6 +17,10 @@ func GetRootCommand() *cobra.Command {
 	var rootCmd = &cobra.Command{
 		Use: "ops",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := checkInvalidFlags(cmd, args); err != nil {
+				return err
+			}
+
 			config := &types.Config{}
 
 			configFlag, _ := cmd.Flags().GetString("config")
@@ -50,4 +57,51 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(DeployCommand())
 
 	return rootCmd
+}
+
+func checkInvalidFlags(cmd *cobra.Command, args []string) error {
+	length := len(args)
+	requiresArg := strings.Contains(cmd.Use, "[")
+	if length > 0 && requiresArg {
+		if length == 1 {
+			args = []string{}
+		} else {
+			args = args[1:]
+		}
+		length--
+	}
+
+	if length > 0 && requiresArg {
+		message := "invalid argument%s or flag%s provided, use --help for usage information."
+		plural := ""
+		if length == 1 {
+			plural = "s"
+		}
+
+		message = fmt.Sprintf(message, plural, plural)
+
+		knownFlag, matched := checkKnownFlag(cmd, args)
+		if matched {
+			message = fmt.Sprintf("%s Probably what you mean was '-%s' instead of '%s'?", message, knownFlag, knownFlag)
+		}
+		return errors.New(message)
+
+	}
+	return nil
+}
+
+func checkKnownFlag(cmd *cobra.Command, args []string) (string, bool) {
+	flags := make([]string, 0)
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		flags = append(flags, f.Name, f.Shorthand)
+	})
+
+	for _, a := range args {
+		for _, fl := range flags {
+			if fl == a {
+				return a, true
+			}
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
```
arknable@arknable-x1c:~/.../ops$ go run ops.go run $HOME/Development/Project/nanovms/example/hello/hello c ../example/issue_441/config.json --show-errors
Error: invalid argument or flag provided, use --help for usage information. Probably what you mean was '-c' instead of 'c'?
Usage:
  ops run [elf] [flags]

Flags:

..........
```