### PR TITLE
Override PackageBaseURL and PackageManifestURL

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -86,7 +86,7 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 	if local {
 		packages, err = api.GetLocalPackageList()
 	} else {
-		packages, err = api.GetPackageList()
+		packages, err = api.GetPackageList(lepton.NewConfig())
 	}
 	if err != nil {
 		log.Panicf("failed getting packages: %s", err)
@@ -152,13 +152,13 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 }
 
 func cmdGetPackage(cmd *cobra.Command, args []string) {
-	downloadPackage(args[0])
+	downloadPackage(args[0], lepton.NewConfig())
 }
 
 func cmdPackageDescribe(cmd *cobra.Command, args []string) {
 	expackage := filepath.Join(packageDirectoryPath(), args[0])
 	if _, err := os.Stat(expackage); os.IsNotExist(err) {
-		expackage = downloadPackage(args[0])
+		expackage = downloadPackage(args[0], lepton.NewConfig())
 	}
 
 	description := path.Join(expackage, "README.md")
@@ -187,7 +187,7 @@ func cmdPackageDescribe(cmd *cobra.Command, args []string) {
 func cmdPackageContents(cmd *cobra.Command, args []string) {
 	expackage := filepath.Join(packageDirectoryPath(), args[0])
 	if _, err := os.Stat(expackage); os.IsNotExist(err) {
-		expackage = downloadPackage(args[0])
+		expackage = downloadPackage(args[0], lepton.NewConfig())
 	}
 
 	filepath.Walk(expackage, func(hostpath string, info os.FileInfo, err error) error {
@@ -232,7 +232,7 @@ func cmdAddPackage(cmd *cobra.Command, args []string) {
 		name = token
 	}
 
-	extractFilePackage(args[0], name)
+	extractFilePackage(args[0], name, lepton.NewConfig())
 
 	fmt.Println(name)
 }

--- a/cmd/download_package.go
+++ b/cmd/download_package.go
@@ -12,9 +12,9 @@ import (
 	"github.com/nanovms/ops/types"
 )
 
-func downloadLocalPackage(pkg string) string {
+func downloadLocalPackage(pkg string, config *types.Config) string {
 	packagesDirPath := localPackageDirectoryPath()
-	return downloadAndExtractPackage(packagesDirPath, pkg)
+	return downloadAndExtractPackage(packagesDirPath, pkg, config)
 }
 
 func localPackageDirectoryPath() string {
@@ -25,8 +25,8 @@ func packageDirectoryPath() string {
 	return path.Join(api.GetOpsHome(), "packages")
 }
 
-func downloadPackage(pkg string) string {
-	return downloadAndExtractPackage(packageDirectoryPath(), pkg)
+func downloadPackage(pkg string, config *types.Config) string {
+	return downloadAndExtractPackage(packageDirectoryPath(), pkg, config)
 }
 
 func copyFile(src, dst string) error {
@@ -87,7 +87,7 @@ func copyDirectory(src string, dst string) error {
 	return nil
 }
 
-func extractFilePackage(pkg string, name string) string {
+func extractFilePackage(pkg string, name string, config *types.Config) string {
 	f, err := os.Stat(pkg)
 	if err != nil {
 		log.Fatal(err)
@@ -95,7 +95,7 @@ func extractFilePackage(pkg string, name string) string {
 
 	if !f.IsDir() {
 		if strings.HasSuffix(pkg, ".tar.gz") {
-			return extractArchivedPackage(pkg, path.Join(localPackageDirectoryPath(), name))
+			return extractArchivedPackage(pkg, path.Join(localPackageDirectoryPath(), name), config)
 		}
 
 		log.Fatalf("Unsupported file format. Supported formats: .tar.gz")
@@ -110,13 +110,13 @@ func extractFilePackage(pkg string, name string) string {
 	return movePackageFiles(tempDirectory, path.Join(localPackageDirectoryPath(), name))
 }
 
-func extractArchivedPackage(pkg string, target string) string {
+func extractArchivedPackage(pkg string, target string, config *types.Config) string {
 	tempDirectory, err := ioutil.TempDir("", "*")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	api.ExtractPackage(pkg, tempDirectory)
+	api.ExtractPackage(pkg, tempDirectory, config)
 	return movePackageFiles(tempDirectory, target)
 }
 
@@ -147,19 +147,19 @@ func movePackageFiles(origin string, target string) string {
 	return target
 }
 
-func downloadAndExtractPackage(packagesDirPath, pkg string) string {
+func downloadAndExtractPackage(packagesDirPath, pkg string, config *types.Config) string {
 	err := os.MkdirAll(packagesDirPath, 0755)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	expackage := path.Join(packagesDirPath, pkg)
-	opsPackage, err := api.DownloadPackage(pkg)
+	opsPackage, err := api.DownloadPackage(pkg, config)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	api.ExtractPackage(opsPackage, packagesDirPath)
+	api.ExtractPackage(opsPackage, packagesDirPath, config)
 
 	err = os.Remove(opsPackage)
 	if err != nil {

--- a/cmd/flags_pkg.go
+++ b/cmd/flags_pkg.go
@@ -42,7 +42,7 @@ func (flags *PkgCommandFlags) MergeToConfig(c *types.Config) (err error) {
 			return fmt.Errorf("No local package with the name %s found", flags.Package)
 		}
 
-		downloadPackage(flags.Package)
+		downloadPackage(flags.Package, c)
 	}
 
 	manifestPath := path.Join(packagePath, "package.manifest")

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -26,7 +26,7 @@ const releaseBaseURL string = "https://storage.googleapis.com/nanos/release/"
 const nightlyReleaseBaseURL string = "https://storage.googleapis.com/nanos/release/nightly/"
 
 // PackageBaseURL gives URL for downloading of packages
-const PackageBaseURL string = "https://storage.googleapis.com/packagehub/%v"
+const PackageBaseURL string = "https://storage.googleapis.com/packagehub"
 
 // PackageManifestURL stores info about all packages
 const PackageManifestURL string = "https://storage.googleapis.com/packagehub/manifest.json"

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -134,7 +134,7 @@ func addCommonFilesToManifest(m *fs.Manifest) error {
 			return err
 		}
 	}
-	ExtractPackage(localtar, commonPath)
+	ExtractPackage(localtar, commonPath, NewConfig())
 
 	localLibDNS := path.Join(commonPath, "libnss_dns.so.2")
 	if _, err := os.Stat(localLibDNS); !os.IsNotExist(err) {
@@ -452,7 +452,7 @@ func DownloadNightlyImages(c *types.Config) error {
 		}
 		// update local timestamp
 		updateLocalTimestamp(remote)
-		ExtractPackage(localtar, NightlyLocalFolder)
+		ExtractPackage(localtar, NightlyLocalFolder, c)
 	}
 
 	return nil
@@ -472,7 +472,7 @@ func DownloadCommonFiles() error {
 	if err != nil {
 		return err
 	}
-	ExtractPackage(localtar, commonPath)
+	ExtractPackage(localtar, commonPath, NewConfig())
 	return nil
 }
 
@@ -504,7 +504,7 @@ func DownloadReleaseImages(version string) error {
 		os.MkdirAll(localFolder, 0755)
 	}
 
-	ExtractPackage(localtar, localFolder)
+	ExtractPackage(localtar, localFolder, NewConfig())
 
 	// FIXME hack to rename stage3.img to kernel.img
 	oldKernel := path.Join(localFolder, "stage3.img")

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -70,7 +70,7 @@ func DownloadPackage(name string, config *types.Config) (string, error) {
 
 	// Check environment variable override
 	ePkgBaseURL := os.Getenv("OPS_PACKAGE_BASE_URL")
-	if len(ePkgBaseURL) > 0 {
+	if ePkgBaseURL != "" {
 		pkgBaseURL = ePkgBaseURL
 	}
 
@@ -137,7 +137,7 @@ func GetPackageList(config *types.Config) (*map[string]Package, error) {
 
 	// Check environment var override
 	ePkgManifestURL := os.Getenv("OPS_PACKAGE_MANIFEST_URL")
-	if len(ePkgManifestURL) > 0 {
+	if ePkgManifestURL != "" {
 		pkgManifestURL = ePkgManifestURL
 	}
 

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -113,6 +113,9 @@ func DownloadPackage(name string, config *types.Config) (string, error) {
 	progressCounter := NewWriteCounter(int(srcStat.Size()))
 	progressCounter.Start()
 	_, err = io.Copy(destFile, io.TeeReader(srcFile, progressCounter))
+	if err != nil {
+		return "", err
+	}
 	progressCounter.Finish()
 
 	return packagepath, nil

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -37,8 +37,8 @@ type Package struct {
 }
 
 // DownloadPackage downloads package by name
-func DownloadPackage(name string) (string, error) {
-	packages, err := GetPackageList()
+func DownloadPackage(name string, config *types.Config) (string, error) {
+	packages, err := GetPackageList(config)
 	if err != nil {
 		return "", nil
 	}
@@ -49,24 +49,119 @@ func DownloadPackage(name string) (string, error) {
 
 	archivename := name + ".tar.gz"
 	packagepath := path.Join(PackagesCache, archivename)
-	if _, err := os.Stat(packagepath); os.IsNotExist(err) {
-		if err = DownloadFileWithProgress(packagepath,
-			fmt.Sprintf(PackageBaseURL, archivename), 600); err != nil {
-			return "", err
+	_, err = os.Stat(packagepath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	if err == nil {
+		return packagepath, nil
+	}
+
+	pkgBaseURL := PackageBaseURL
+
+	// Check config override
+	if config != nil {
+		cPkgBaseURL := strings.Trim(config.PackageBaseURL, " ")
+		if len(cPkgBaseURL) > 0 {
+			pkgBaseURL = cPkgBaseURL
 		}
 	}
+
+	// Check environment variable override
+	ePkgBaseURL := os.Getenv("OPS_PACKAGE_BASE_URL")
+	if len(ePkgBaseURL) > 0 {
+		pkgBaseURL = ePkgBaseURL
+	}
+
+	isNetworkRepo := !strings.HasPrefix(pkgBaseURL, "file://")
+	if isNetworkRepo {
+		var fileURL string
+		if strings.HasSuffix(pkgBaseURL, "/") {
+			fileURL = pkgBaseURL + archivename
+		} else {
+			fileURL = fmt.Sprintf("%s/%s", pkgBaseURL, archivename)
+		}
+
+		if err = DownloadFileWithProgress(packagepath, fileURL, 600); err != nil {
+			return "", err
+		}
+
+		return packagepath, nil
+	}
+
+	pkgBaseURL = strings.TrimPrefix(pkgBaseURL, "file://")
+	srcPath := filepath.Join(pkgBaseURL, archivename)
+
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return "", err
+	}
+	defer srcFile.Close()
+
+	srcStat, err := srcFile.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	destFile, err := os.Create(packagepath)
+	if err != nil {
+		return "", err
+	}
+	defer destFile.Close()
+
+	progressCounter := NewWriteCounter(int(srcStat.Size()))
+	progressCounter.Start()
+	_, err = io.Copy(destFile, io.TeeReader(srcFile, progressCounter))
+	progressCounter.Finish()
+
 	return packagepath, nil
 }
 
 // GetPackageList provides list of packages
-func GetPackageList() (*map[string]Package, error) {
+func GetPackageList(config *types.Config) (*map[string]Package, error) {
 	var err error
 
+	pkgManifestURL := PackageManifestURL
+
+	// Check config override
+	if config != nil {
+		cPkgManifestURL := strings.Trim(config.PackageManifestURL, " ")
+		if len(cPkgManifestURL) > 0 {
+			pkgManifestURL = cPkgManifestURL
+		}
+	}
+
+	// Check environment var override
+	ePkgManifestURL := os.Getenv("OPS_PACKAGE_MANIFEST_URL")
+	if len(ePkgManifestURL) > 0 {
+		pkgManifestURL = ePkgManifestURL
+	}
+
 	packageManifest := GetPackageManifestFile()
-	stat, err := os.Stat(packageManifest)
-	if os.IsNotExist(err) || PackageManifestChanged(stat, PackageManifestURL) {
-		if err = DownloadFile(packageManifest, PackageManifestURL, 10, false); err != nil {
+	if strings.HasPrefix(pkgManifestURL, "file://") {
+		destFile, err := os.OpenFile(packageManifest, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+		if err != nil {
 			return nil, err
+		}
+		defer destFile.Close()
+
+		pkgManifestURL = strings.TrimPrefix(pkgManifestURL, "file://")
+		srcFile, err := os.Open(pkgManifestURL)
+		if err != nil {
+			return nil, err
+		}
+		defer srcFile.Close()
+
+		if _, err := io.Copy(destFile, srcFile); err != nil {
+			return nil, err
+		}
+	} else {
+		stat, err := os.Stat(packageManifest)
+		if os.IsNotExist(err) || PackageManifestChanged(stat, pkgManifestURL) {
+			if err = DownloadFile(packageManifest, pkgManifestURL, 10, false); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -164,7 +259,7 @@ func sha256Of(filename string) string {
 
 // ExtractPackage extracts package in ops home.
 // This function is currently over-loaded.
-func ExtractPackage(archive string, dest string) {
+func ExtractPackage(archive, dest string, config *types.Config) {
 	sha := sha256Of(archive)
 
 	// hack
@@ -176,7 +271,7 @@ func ExtractPackage(archive string, dest string) {
 		fname := filepath.Base(archive)
 		fname = strings.ReplaceAll(fname, ".tar.gz", "")
 
-		list, err := GetPackageList()
+		list, err := GetPackageList(config)
 		if err != nil {
 			panic(err)
 		}

--- a/types/config.go
+++ b/types/config.go
@@ -102,6 +102,12 @@ type Config struct {
 
 	// VolumesDir is the directory used to store and fetch volumes
 	VolumesDir string
+
+	// PackageBaseURL gives URL for downloading of packages
+	PackageBaseURL string
+
+	// PackageManifestURL stores info about all packages
+	PackageManifestURL string
 }
 
 // ProviderConfig give provider details


### PR DESCRIPTION
Added support to override `PackageBaseURL` and `PackageManifestURL`. The override locations based on priority in order are `$HOME/.opsrc` then environment variable `OPS_PACKAGE_BASE_URL` and `OPS_PACKAGE_MANIFEST_URL` .... meaning environment variable will override `.opsrc`.

Added also support for local folder using `file://` prefix, e.g. if we have repo directory in local filesystem and we want to use it, we can override it like this
```
{
	"PackageBaseURL": "file:///home/arknable/Development/Project/nanovms/example/package_repo",
	"PackageManifestURL": "file:///home/arknable/Development/Project/nanovms/example/package_repo/manifest.json"
}
```

or using environment variables with above values.