### PR TITLE
Allow `Language`, `Runtime` and `Description` properties in manifest configuration

### DIFF
--- a/cmd/flags_pkg.go
+++ b/cmd/flags_pkg.go
@@ -59,6 +59,10 @@ func (flags *PkgCommandFlags) MergeToConfig(c *types.Config) (err error) {
 	c.Program = pkgConfig.Program
 	c.Version = pkgConfig.Version
 
+	c.Language = pkgConfig.Language
+	c.Runtime = pkgConfig.Runtime
+	c.Description = pkgConfig.Description
+
 	c.Args = append(pkgConfig.Args, c.Args...)
 	c.Dirs = append(pkgConfig.Dirs, c.Dirs...)
 	c.Files = append(pkgConfig.Files, c.Files...)

--- a/types/config.go
+++ b/types/config.go
@@ -91,6 +91,15 @@ type Config struct {
 	// Version
 	Version string
 
+	// Language
+	Language string
+
+	// Runtime
+	Runtime string
+
+	// Description
+	Description string
+
 	// VolumesDir is the directory used to store and fetch volumes
 	VolumesDir string
 }


### PR DESCRIPTION
Whenever a package is added to `local_packages`, the properties `Language`, `Runtime` and `Description` are removed. Making `ops pkg list --local` not displaying those information even though having columns dedicated for them.

This PR fixes this issue by keeping the related properties.