### PR TITLE
Fix executable path construction to support binary inside sysroot

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -280,6 +280,8 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	executableName := c.Program
 	if strings.Contains(executableName, packageFolder) {
 		executableName = filepath.Base(executableName)
+	} else {
+		executableName = filepath.Join(lepton.PackageSysRootFolderName, executableName)
 	}
 	lepton.ValidateELF(filepath.Join(pkgFlags.PackagePath(), executableName))
 

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -22,6 +22,9 @@ import (
 	"github.com/nanovms/ops/types"
 )
 
+// PackageSysRootFolderName is the name of package root folder
+const PackageSysRootFolderName = "sysroot"
+
 // PackageList contains a list of known packages.
 type PackageList struct {
 	list map[string]Package


### PR DESCRIPTION
Some module specify program location inside `sysroot`, hence we need to check it first and append the required `sysroot` folder.