### PR TITLE
Added option to override home path via OPS_HOME environment variable

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -280,6 +280,8 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	executableName := c.Program
 	if strings.Contains(executableName, packageFolder) {
 		executableName = filepath.Base(executableName)
+	} else {
+		executableName = filepath.Join(lepton.PackageSysRootFolderName, executableName)
 	}
 	lepton.ValidateELF(filepath.Join(pkgFlags.PackagePath(), executableName))
 

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -66,7 +66,7 @@ func GetOpsHome() string {
 	if envOpsHome != "" {
 		altHomeDir := filepath.Join(envOpsHome, ".ops")
 		if _, err := os.Stat(altHomeDir); os.IsNotExist(err) {
-			if err = os.MkdirAll(altHomeDir, os.ModePerm); err != nil {
+			if err = os.MkdirAll(altHomeDir, 0755); err != nil {
 				fmt.Println("failed to create OPS home directory at ", altHomeDir)
 				exitWithError(err.Error())
 			}

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -58,10 +58,20 @@ func GetOpsHome() string {
 	}
 	opshome := path.Join(home, ".ops")
 
-	// Check home folder override via OPS_HOME environment variable
+	// Check home directory override via OPS_HOME environment variable.
+	// OPS_HOME should not point to .ops directory replacement,
+	// but should point to the parent directory in which .ops directory located,
+	// so the homedir path after OPS_HOME set should be OPS_HOME/.ops.
 	envOpsHome := os.Getenv("OPS_HOME")
 	if envOpsHome != "" {
-		opshome = envOpsHome
+		altHomeDir := filepath.Join(envOpsHome, ".ops")
+		if _, err := os.Stat(altHomeDir); os.IsNotExist(err) {
+			if err = os.MkdirAll(altHomeDir, os.ModePerm); err != nil {
+				fmt.Println("failed to create OPS home directory at ", altHomeDir)
+				exitWithError(err.Error())
+			}
+		}
+		opshome = altHomeDir
 	}
 
 	images := path.Join(opshome, "images")

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -56,8 +56,14 @@ func GetOpsHome() string {
 	if err != nil {
 		panic(err)
 	}
-
 	opshome := path.Join(home, ".ops")
+
+	// Check home folder override via OPS_HOME environment variable
+	envOpsHome := os.Getenv("OPS_HOME")
+	if envOpsHome != "" {
+		opshome = envOpsHome
+	}
+
 	images := path.Join(opshome, "images")
 	instances := path.Join(opshome, "instances")
 	manifests := path.Join(opshome, "manifests")

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -22,6 +22,9 @@ import (
 	"github.com/nanovms/ops/types"
 )
 
+// PackageSysRootFolderName is the name of package root folder
+const PackageSysRootFolderName = "sysroot"
+
 // PackageList contains a list of known packages.
 type PackageList struct {
 	list map[string]Package

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -267,12 +267,13 @@ func sha256Of(filename string) string {
 // This function is currently over-loaded.
 func ExtractPackage(archive, dest string, config *types.Config) {
 	sha := sha256Of(archive)
+	homeDirName := filepath.Base(GetOpsHome())
 
 	// hack
 	// this only verifies for packages - unfortunately this function is
 	// used for extracting releases (which currently don't have
 	// checksums)
-	if strings.Contains(archive, ".ops/packages") {
+	if strings.Contains(archive, filepath.Join(homeDirName, "packages")) {
 
 		fname := filepath.Base(archive)
 		fname = strings.ReplaceAll(fname, ".tar.gz", "")


### PR DESCRIPTION
`OPS_HOME` value should be the parent directory in which `.ops` directory located, hence the home directory will be `$OPS_HOME/.ops`. if `$OPS_HOME/.ops` not exists, it will be created automatically.