### PR TITLE
Log missing files during image build instead of returning error

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -173,7 +173,7 @@ func addFilesFromPackage(packagepath string, m *fs.Manifest) {
 
 		err = m.AddFile(filePath[1], hostpath)
 		if err != nil {
-			return err
+			log.Error(err)
 		}
 		return nil
 	})
@@ -195,7 +195,7 @@ func addFilesFromPackage(packagepath string, m *fs.Manifest) {
 		vmpath := filepath.Join(string(os.PathSeparator), packageName, filePath[1])
 		err = m.AddFile(vmpath, hostpath)
 		if err != nil {
-			return err
+			log.Error(err)
 		}
 		return nil
 	})


### PR DESCRIPTION
While building an image and adding package files to it, if there is a
problem with a file such as a broken symlink, the addFile walk aborts
but the error is not handled. This has been changed so the err is logged
as an error and printed to the user but the image build continues since
missing package files aren't always required for the app to run. This fixes
some ops pkg load regressions such as in the python2.7 package.