### PR TITLE
Manifest passthrough: add support for non-string config options

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -367,7 +367,7 @@ func (m *Manifest) AddLibrary(path string) {
 }
 
 // AddPassthrough to add key, value directly to manifest
-func (m *Manifest) AddPassthrough(key, value string) {
+func (m *Manifest) AddPassthrough(key string, value interface{}) {
 	m.root[key] = value
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	NoTrace []string
 
 	// Straight passthrough of options to manifest
-	ManifestPassthrough map[string]string
+	ManifestPassthrough map[string]interface{}
 
 	// Program
 	Program string


### PR DESCRIPTION
This allows setting arbitrary configuration options in a manifest, e.g.:
```
{
  "ManifestPassthrough": {
    "my_manifest_setting": {
      "setting1":"value1",
      "setting2":"value2"
    }
  }
}
```
Can be used to configure the syslog klib (https://github.com/nanovms/nanos/pull/1497).