### PR TITLE
1086 Fix directory mapping

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -509,6 +509,8 @@ func (m *Manifest) MkdirPath(path string) {
 }
 
 func mkDirPath(parent map[string]interface{}, path string) map[string]interface{} {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
 	parts := strings.Split(path, "/")
 	for _, element := range parts {
 		parent = mkDir(parent, element)


### PR DESCRIPTION
- For a directory, use newly-added `MkdirPath()` instead of `AddDirectory()` of manifest.
- Handle symlink using `AddLink()` of manifest.
