### PR TITLE
fs/tfs.encodeMetadata(): add support for slices of arbitray data

### DIFF
--- a/fs/tfs.go
+++ b/fs/tfs.go
@@ -141,6 +141,15 @@ func (t *tfs) encodeMetadata(name string, value interface{}) {
 		t.encodeTuple(tuple)
 		return
 	}
+	slice, isSlice := value.([]interface{})
+	if isSlice {
+		tuple := make(map[string]interface{})
+		for i, val := range slice {
+			tuple[strconv.Itoa(i)] = val
+		}
+		t.encodeTuple(tuple)
+		return
+	}
 	t.encodeTuple(value.(map[string]interface{}))
 }
 


### PR DESCRIPTION
This allows specifying a "ManifestPassthrough" option with non-string attribute values, which may be necessary to configure kernel libraries such as cloud_init.
Example:
```
"ManifestPassthrough": {
  "cloud_init": {
    "download": [
      {"src": "https://example1.com/README.md", "dest": "1.md"},
      {"src": "https://example2.com/README.md", "dest": "2.md"}
    ]
  }
}
```