### PR TITLE
Update `ops pkg add`'s description

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -52,7 +52,7 @@ func PackageCommands() *cobra.Command {
 
 	var cmdAddPackage = &cobra.Command{
 		Use:   "add [package]",
-		Short: "push a folder or a zipped package to the local cache",
+		Short: "push a folder or a .tar.gz archived package to the local cache",
 		Args:  cobra.MinimumNArgs(1),
 		Run:   cmdAddPackage,
 	}


### PR DESCRIPTION
Actual description for `ops pkg add`, "push a folder or a zipped package to the local cache", wasn't right as we don't allow zipped package.
This PR fixes the description to a better one.
