### PR TITLE
Check qemu version in 'pkg load' and 'run' commands 

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/log"
+	"github.com/nanovms/ops/qemu"
 )
 
 // PackageCommands gives package related commands
@@ -295,6 +296,15 @@ func LoadCommand() *cobra.Command {
 }
 
 func loadCommandHandler(cmd *cobra.Command, args []string) {
+	// Check if qemu being used is supported.
+	supported, err := qemu.CheckIfVersionSupported()
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	if !supported {
+		return
+	}
+
 	flags := cmd.Flags()
 
 	configFlags := NewConfigCommandFlags(flags)
@@ -308,7 +318,7 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	c := lepton.NewConfig()
 
 	mergeContainer := NewMergeConfigContainer(configFlags, globalFlags, nightlyFlags, buildImageFlags, runLocalInstanceFlags, pkgFlags)
-	err := mergeContainer.Merge(c)
+	err = mergeContainer.Merge(c)
 	if err != nil {
 		exitWithError(err.Error())
 	}

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/qemu"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +31,14 @@ func RunCommand() *cobra.Command {
 }
 
 func runCommandHandler(cmd *cobra.Command, args []string) {
+	// Check if qemu being used is supported.
+	supported, err := qemu.CheckIfVersionSupported()
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	if !supported {
+		return
+	}
 
 	c := lepton.NewConfig()
 
@@ -49,7 +58,7 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 	runLocalInstanceFlags := NewRunLocalInstanceCommandFlags(flags)
 
 	mergeContainer := NewMergeConfigContainer(configFlags, globalFlags, nightlyFlags, nanosVersionFlags, buildImageFlags, runLocalInstanceFlags)
-	err := mergeContainer.Merge(c)
+	err = mergeContainer.Merge(c)
 	if err != nil {
 		exitWithError(err.Error())
 	}

--- a/qemu/qemu_version.go
+++ b/qemu/qemu_version.go
@@ -1,0 +1,43 @@
+package qemu
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CheckIfVersionSupported checks if current version being used is supported.
+func CheckIfVersionSupported() (bool, error) {
+	versionWarnMsg := "\nsupported QEMU version is 2.9 or above, please do upgrade.\n"
+	version, err := Version()
+	if err != nil {
+		return false, err
+	}
+	versionParts := strings.Split(version, ".")
+
+	vMajor, err := strconv.ParseInt(versionParts[0], 10, 32)
+	if err != nil {
+		return false, err
+	}
+
+	if vMajor < 2 {
+		fmt.Println(versionWarnMsg)
+		return false, err
+	}
+
+	if len(versionParts) < 2 {
+		fmt.Println(versionWarnMsg)
+		return false, err
+	}
+
+	vMinor, err := strconv.ParseInt(versionParts[1], 10, 32)
+	if err != nil {
+		return false, err
+	}
+
+	if vMajor == 2 && vMinor < 9 {
+		fmt.Println(versionWarnMsg)
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
Warn user if their installed QEMU version is older than 2.9

```
[root@localhost ops_example]# qemu-system-x86_64 --version
QEMU emulator version 1.5.3 (qemu-kvm-1.5.3-175.el7_9.4), Copyright (c) 2003-2008 Fabrice Bellard
[root@localhost ops_example]# ops run hello

supported QEMU version is 2.9 or above, please do upgrade.

root@localhost ops_example]# 
```

```
[root@localhost ops_example]# ops pkg load node_v14.2.0 -f -n -a hello.js

supported QEMU version is 2.9 or above, please do upgrade.

[root@localhost ops_example]# 
```