### PR TITLE
Minimum arguments should be 1

### DIFF
--- a/cmd/cmd_image.go
+++ b/cmd/cmd_image.go
@@ -157,7 +157,7 @@ func imageDeleteCommand() *cobra.Command {
 		Use:   "delete <image_name>",
 		Short: "delete images from provider",
 		Run:   imageDeleteCommandHandler,
-		Args:  cobra.MinimumNArgs(0),
+		Args:  cobra.MinimumNArgs(1),
 	}
 
 	cmdImageDelete.PersistentFlags().StringP("lru", "", "", "clean least recently used images with a time notation. Use \"1w\" notation to delete images older than one week. Other notation examples are 300d, 3w, 1m and 2y.")


### PR DESCRIPTION
Fixed minimum argument for `image delete` which was set to 0.