### PR TITLE
Make debug flag executable checks non-fatal

### DIFF
--- a/cmd/flags_run_local_instance.go
+++ b/cmd/flags_run_local_instance.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nanovms/ops/log"
 	"github.com/nanovms/ops/types"
 
 	"github.com/go-errors/errors"
@@ -46,19 +47,24 @@ func (flags *RunLocalInstanceCommandFlags) MergeToConfig(c *types.Config) error 
 
 		c.Debugflags = append(c.Debugflags, "noaslr")
 
-		var elfFile *elf.File
+		if len(c.ProgramPath) > 0 {
+			var elfFile *elf.File
 
-		elfFile, err := api.GetElfFileInfo(c.ProgramPath)
-		if err != nil {
-			return err
-		}
+			elfFile, err := api.GetElfFileInfo(c.ProgramPath)
+			if err != nil {
+				return err
+			}
 
-		if api.IsDynamicLinked(elfFile) {
-			return fmt.Errorf("Program %s must be linked statically", c.ProgramPath)
-		}
+			if api.IsDynamicLinked(elfFile) {
+				log.Errorf("Program %s must be linked statically", c.ProgramPath)
+			}
 
-		if !api.HasDebuggingSymbols(elfFile) {
-			return fmt.Errorf("Program %s must be compiled with debugging symbols", c.ProgramPath)
+			if !api.HasDebuggingSymbols(elfFile) {
+				log.Errorf("Program %s must be compiled with debugging symbols", c.ProgramPath)
+			}
+
+		} else {
+			log.Errorf("Debug executable not found (is this a package?)")
 		}
 	}
 


### PR DESCRIPTION
The debug flag implements checks for a valid, statically linked executable
with debug symbols and aborts the command if failed. This prevents using
the debug flag with packages or arbitrary executables where you want to
debug nanos. This change prints out the failed checks as an error message
but does not abort the command.