### PR TITLE
Handle relative or absolute program paths

### DIFF
--- a/cmd/cmd_deploy.go
+++ b/cmd/cmd_deploy.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -51,8 +49,11 @@ func deployCommandHandler(cmd *cobra.Command, args []string) {
 
 	program := args[0]
 	c.Program = program
-	curdir, _ := os.Getwd()
-	c.ProgramPath = path.Join(curdir, c.Program)
+	var err error
+	c.ProgramPath, err = filepath.Abs(c.Program)
+	if err != nil {
+		exitWithError(err.Error())
+	}
 	checkProgramExists(c.Program)
 
 	if len(c.Args) == 0 {
@@ -62,7 +63,7 @@ func deployCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	mergeConfigContainer := NewMergeConfigContainer(configFlags, globalFlags, nightlyFlags, nanosVersionFlags, buildImageFlags, providerFlags, pkgFlags, createInstanceFlags)
-	err := mergeConfigContainer.Merge(c)
+	err = mergeConfigContainer.Merge(c)
 	if err != nil {
 		exitWithError(err.Error())
 	}

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -1,8 +1,7 @@
 package cmd
 
 import (
-	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
@@ -35,8 +34,11 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 
 	program := args[0]
 	c.Program = program
-	curdir, _ := os.Getwd()
-	c.ProgramPath = path.Join(curdir, c.Program)
+	var err error
+	c.ProgramPath, err = filepath.Abs(c.Program)
+	if err != nil {
+		exitWithError(err.Error())
+	}
 	checkProgramExists(c.Program)
 
 	flags := cmd.Flags()
@@ -49,7 +51,7 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 	runLocalInstanceFlags := NewRunLocalInstanceCommandFlags(flags)
 
 	mergeContainer := NewMergeConfigContainer(configFlags, globalFlags, nightlyFlags, nanosVersionFlags, buildImageFlags, runLocalInstanceFlags)
-	err := mergeContainer.Merge(c)
+	err = mergeContainer.Merge(c)
 	if err != nil {
 		exitWithError(err.Error())
 	}


### PR DESCRIPTION
Use filepath.Abs to create ProgramPath which automatically handles relative
or absolute paths instead of joining path elements manually.