### PR TITLE
Commands: add support for cross-build environment

### DIFF
--- a/cmd/cmd_env.go
+++ b/cmd/cmd_env.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/nanovms/ops/crossbuild"
+	api "github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/log"
+	"github.com/spf13/cobra"
+)
+
+// EnvCommand provides cross-build features.
+func EnvCommand() *cobra.Command {
+	cmdInstall := &cobra.Command{
+		Use:   "install",
+		Short: "Install environment",
+		Run:   envInstall,
+	}
+
+	cmdBuild := &cobra.Command{
+		Use:   "build <build_file> [flags]",
+		Short: "Build application in environment",
+		Args:  cobra.MinimumNArgs(1),
+		Run:   envBuild,
+	}
+	flags := cmdBuild.PersistentFlags()
+	flags.BoolP("create-image", "", false, "create Nanos image from environment")
+	PersistConfigCommandFlags(flags)
+	PersistNightlyCommandFlags(flags)
+	PersistNanosVersionCommandFlags(flags)
+	PersistBuildImageCommandFlags(flags)
+
+	cmdCopy := &cobra.Command{
+		Use:   "copy <local_dir> [flags]",
+		Short: "Copy files from environment to local directory",
+		Args:  cobra.MinimumNArgs(1),
+		Run:   envCopy,
+	}
+	flags = cmdCopy.PersistentFlags()
+	PersistConfigCommandFlags(flags)
+
+	cmdUninstall := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall environment",
+		Run:   envUninstall,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "env command [flags]",
+		Short: "Cross-build environment commands",
+		Args:  cobra.OnlyValidArgs,
+		ValidArgs: []string{
+			cmdInstall.Use,
+			cmdBuild.Use,
+			cmdCopy.Use,
+			cmdUninstall.Use,
+		},
+	}
+	cmd.AddCommand(
+		cmdInstall,
+		cmdBuild,
+		cmdCopy,
+		cmdUninstall,
+	)
+	return cmd
+}
+
+// Action for install command.
+func envInstall(cmd *cobra.Command, args []string) {
+	env := loadEnvironment(false)
+	if env.IsInstalled() {
+		exitWithError("Enviroment already installed")
+	}
+	if err := env.Install(); err != nil {
+		exitWithError(fmt.Sprintf("Failed to install environment: %v", err))
+	}
+}
+
+// Action for build command.
+func envBuild(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	createImage, _ := flags.GetBool("create-image")
+	c := api.NewConfig()
+	configFlags := NewConfigCommandFlags(flags)
+	nightlyFlags := NewNightlyCommandFlags(flags)
+	nanosVersionFlags := NewNanosVersionCommandFlags(flags)
+	buildImageFlags := NewBuildImageCommandFlags(flags)
+	mergeContainer := NewMergeConfigContainer(configFlags, nightlyFlags, nanosVersionFlags, buildImageFlags)
+	err := mergeContainer.Merge(c)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	env := loadEnvironment(true)
+	if createImage {
+		if c.Program == "" {
+			exitForCmd(cmd, "When creating an image, program must be specified in config file")
+		}
+		if c.RunConfig.Imagename == "" {
+			c.RunConfig.Imagename = c.Program
+		}
+	}
+	tmpRoot := false
+	if c.TargetRoot == "" {
+		if createImage {
+			c.TargetRoot, err = ioutil.TempDir("", "*")
+			if err != nil {
+				exitWithError(err.Error())
+			}
+			tmpRoot = true
+		} else {
+			exitForCmd(cmd, "When not creating an image, target root must be specified "+
+				"(WARNING: any files in the target root folder will be overwritten)")
+		}
+	}
+	if err = env.Boot(); err != nil {
+		log.Errorf("Failed to start environment: %v", err)
+		env = nil
+		goto cleanup
+	}
+	if err = env.RunCommands(args[0]); err != nil {
+		log.Errorf("Failed to build application: %v", err)
+		goto cleanup
+	}
+	if err = env.GetFiles(c, c.TargetRoot); err != nil {
+		log.Errorf("Failed to get application files: %v", err)
+		goto cleanup
+	}
+	if createImage {
+		c.LocalFilesParentDirectory = c.TargetRoot
+		var p api.Provider
+		var ctx *api.Context
+		p, ctx, err = getProviderAndContext(c, "onprem")
+		if err != nil {
+			log.Errorf("Failed to get provider: %v", err)
+			goto cleanup
+		}
+		_, err = p.BuildImage(ctx)
+		if err != nil {
+			log.Errorf("Failed to build image: %v", err)
+		} else {
+			fmt.Printf("On-prem image '%s' created...\n", c.RunConfig.Imagename)
+		}
+	}
+cleanup:
+	if env != nil {
+		env.Shutdown()
+	}
+	if tmpRoot {
+		os.RemoveAll(c.TargetRoot)
+	}
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// Action for copy command.
+func envCopy(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+	c := api.NewConfig()
+	configFlags := NewConfigCommandFlags(flags)
+	mergeContainer := NewMergeConfigContainer(configFlags)
+	err := mergeContainer.Merge(c)
+	if err != nil {
+		exitWithError(err.Error())
+	}
+	env := loadEnvironment(true)
+	if err = env.Boot(); err != nil {
+		log.Errorf("Failed to start environment: %v", err)
+		os.Exit(1)
+	}
+	if err = env.GetFiles(c, args[0]); err != nil {
+		log.Errorf("Failed to get application files: %v", err)
+	}
+	env.Shutdown()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// Action for uninstall command.
+func envUninstall(cmd *cobra.Command, args []string) {
+	env := loadEnvironment(true)
+	if err := env.Uninstall(); err != nil {
+		exitWithError(fmt.Sprintf("Failed to uninstall environment: %v", err))
+	}
+}
+
+// Loads environment, optionally checking that it is installed.
+func loadEnvironment(checkInstall bool) *crossbuild.Environment {
+	env, err := crossbuild.DefaultEnvironment()
+	if err != nil {
+		exitWithError(fmt.Sprintf("Failed to load environment: %v", err))
+	}
+	if checkInstall && !env.IsInstalled() {
+		exitWithError("Enviroment not installed")
+	}
+	return env
+}

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -46,6 +46,7 @@ func GetRootCommand() *cobra.Command {
 	PersistGlobalCommandFlags(rootCmd.PersistentFlags())
 
 	rootCmd.AddCommand(BuildCommand())
+	rootCmd.AddCommand(EnvCommand())
 	rootCmd.AddCommand(ImageCommands())
 	rootCmd.AddCommand(InstanceCommands())
 	rootCmd.AddCommand(ProfileCommand())

--- a/crossbuild/crossbuild.go
+++ b/crossbuild/crossbuild.go
@@ -1,0 +1,82 @@
+package crossbuild
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/log"
+)
+
+var (
+	// ErrMsgEnvironmentInitFailed occurs if environment initialization failed.
+	ErrMsgEnvironmentInitFailed = "Failed to initialize crossbuild environment"
+
+	// CrossBuildHomeDirPath is the crossbuild home directory.
+	CrossBuildHomeDirPath = filepath.Join(lepton.GetOpsHome(), "crossbuild")
+
+	// SupportedEnvironmentsFileName is name of the file that list supported environments.
+	SupportedEnvironmentsFileName = "environments.json"
+
+	// EnvironmentImageDirPath is the directory that keeps environment images.
+	EnvironmentImageDirPath = filepath.Join(CrossBuildHomeDirPath, "images")
+)
+
+func init() {
+	directories := []string{
+		CrossBuildHomeDirPath,
+		EnvironmentImageDirPath,
+	}
+	for _, dir := range directories {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err = os.MkdirAll(dir, 0755); err != nil {
+				log.Errorf(ErrMsgEnvironmentInitFailed+": %s", err.Error())
+			}
+		}
+	}
+}
+
+// DefaultEnvironment returns default environment.
+func DefaultEnvironment() (*Environment, error) {
+	environments, err := supportedEnvironments()
+	if err != nil {
+		return nil, err
+	}
+	for _, env := range environments {
+		if env.IsDefault {
+			return &env, nil
+		}
+	}
+	return &environments[0], nil
+}
+
+// supportedEnvironments returns list of supported environments.
+func supportedEnvironments() ([]Environment, error) {
+	listFilePath := filepath.Join(CrossBuildHomeDirPath, SupportedEnvironmentsFileName)
+	if _, err := os.Stat(listFilePath); os.IsNotExist(err) {
+		if err = downloadEnvList(); err != nil {
+			return nil, err
+		}
+	}
+	content, err := ioutil.ReadFile(listFilePath)
+	if err != nil {
+		return nil, err
+	}
+	var environments []Environment
+	if err = json.Unmarshal(content, &environments); err != nil {
+		return nil, err
+	}
+	return environments, nil
+}
+
+// downloadEnvList downloads list of supported environments.
+func downloadEnvList() error {
+	targetPath := filepath.Join(CrossBuildHomeDirPath, SupportedEnvironmentsFileName)
+	downloadURL := "https://" + filepath.Join(EnvironmentDownloadBaseURL, SupportedEnvironmentsFileName)
+	if err := lepton.DownloadFile(targetPath, downloadURL, 30, true); err != nil {
+		return err
+	}
+	return nil
+}

--- a/crossbuild/env.go
+++ b/crossbuild/env.go
@@ -1,0 +1,419 @@
+package crossbuild
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/bramvdbogaerde/go-scp"
+	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/log"
+	"github.com/nanovms/ops/qemu"
+	"github.com/nanovms/ops/types"
+	"github.com/tj/go-spin"
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	// EnvironmentDownloadBaseURL is the base url to download environment image.
+	EnvironmentDownloadBaseURL = "storage.googleapis.com/nanos-build-envs"
+
+	// EnvironmentImageFileExtension is extension for environment image file.
+	EnvironmentImageFileExtension = ".qcow2"
+
+	// EnvironmentUsername is username for regular account.
+	EnvironmentUsername = "user"
+
+	// EnvironmentUserPassword is password for regular account.
+	EnvironmentUserPassword = "user"
+
+	// EnvironmentRootPassword is password for admin account.
+	EnvironmentRootPassword = "root"
+)
+
+// Environment is a virtualized crossbuild operating system.
+type Environment struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	IsDefault bool   `json:"is_default"`
+	SSHPort   int    `json:"-"`
+	PID       int    `json:"-"`
+}
+
+// IsInstalled returns whether the environment is installed.
+func (env *Environment) IsInstalled() bool {
+	imageFilePath := filepath.Join(EnvironmentImageDirPath, env.ID+EnvironmentImageFileExtension)
+	info, err := os.Stat(imageFilePath)
+	if err != nil {
+		return false
+	}
+	if info.Mode().IsRegular() {
+		return true
+	}
+	return false
+}
+
+// Install pulls environment image from remote storage.
+func (env *Environment) Install() error {
+	compressedImgFileName := env.ID + ".zip"
+	compressedImgFilePath := filepath.Join(EnvironmentImageDirPath, compressedImgFileName)
+	downloadURL := "https://" + path.Join(EnvironmentDownloadBaseURL, compressedImgFileName)
+	if err := lepton.DownloadFileWithProgress(compressedImgFilePath, downloadURL, 1800); err != nil {
+		return err
+	}
+	defer os.Remove(compressedImgFilePath)
+	zipReader, err := zip.OpenReader(compressedImgFilePath)
+	if err != nil {
+		return err
+	}
+	defer zipReader.Close()
+	for _, file := range zipReader.File {
+		if !file.FileInfo().Mode().IsRegular() {
+			continue
+		}
+		targetPath := filepath.Join(EnvironmentImageDirPath, file.Name)
+		targetFile, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer targetFile.Close()
+		zFile, err := file.Open()
+		if err != nil {
+			return err
+		}
+		defer zFile.Close()
+		log.Infof("Extracting file %s", file.Name)
+		if _, err := io.Copy(targetFile, zFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Boot starts environment VM.
+func (env *Environment) Boot() error {
+	if env.PID == 0 {
+		hypervisor := qemu.HypervisorInstance()
+		if hypervisor == nil {
+			return errors.New("no hypervisor found in PATH")
+		}
+		env.SSHPort = 1024
+		for env.SSHPort < 0xFFFF { // Look for a free TCP port
+			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%v", env.SSHPort))
+			if err != nil {
+				break
+			} else {
+				conn.Close()
+				env.SSHPort++
+			}
+		}
+		cmd := hypervisor.Command(&types.RunConfig{
+			Accel:     true,
+			Imagename: filepath.Join(EnvironmentImageDirPath, env.ID+EnvironmentImageFileExtension),
+			Vga:       true,
+			Memory:    "2G",
+			Ports: []string{
+				fmt.Sprintf("%d-%d", env.SSHPort, 22),
+			},
+		})
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		if cmd.Process == nil {
+			return errors.New("boot failure")
+		}
+		env.PID = cmd.Process.Pid
+	}
+	var (
+		wg              = &sync.WaitGroup{}
+		timedOut        = false
+		checkCount      = 0
+		keepChecking    = true
+		interruptSignal = make(chan os.Signal, 1)
+		interrupted     = false
+	)
+	wg.Add(1)
+	signal.Notify(interruptSignal, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-interruptSignal
+		interrupted = true
+		keepChecking = false
+	}()
+	spinner := spin.New()
+	go func() {
+		for {
+			fmt.Printf("\r%s Starting environment", spinner.Next())
+			time.Sleep(time.Second)
+			if !keepChecking {
+				break
+			}
+			checkCount++
+			if checkCount >= 10 {
+				if env.IsReady() {
+					fmt.Print("   OK")
+					break
+				}
+				if checkCount >= 60 {
+					timedOut = true
+					break
+				}
+			}
+		}
+		fmt.Println("")
+		wg.Done()
+	}()
+	wg.Wait()
+	if interrupted {
+		return errors.New("interrupted by user")
+	}
+	if timedOut {
+		return errors.New("not responding")
+	}
+	return nil
+}
+
+// IsReady returns true if communication with environment VM can be established.
+func (env *Environment) IsReady() bool {
+	vmCmd := env.NewCommand("ls /")
+	vmCmd.SuppressOutput = true
+	if err := vmCmd.Execute(); err != nil {
+		return false
+	}
+	return vmCmd.StdOutput() != ""
+}
+
+// RunCommands runs a sequence of commands in the VM.
+func (env *Environment) RunCommands(cmdFile string) error {
+	contents, err := ioutil.ReadFile(cmdFile)
+	if err != nil {
+		return fmt.Errorf("cannot read command file: %v", err)
+	}
+	vmCmd := env.NewEmptyCommand()
+	for _, cmd := range strings.Split(string(contents), "\n") {
+		vmCmd = vmCmd.Then(cmd)
+	}
+	if err := vmCmd.AsAdmin().Execute(); err != nil {
+		return errors.New("cannot execute build commands")
+	}
+	return nil
+}
+
+// GetFiles copies image files from VM to local directory.
+func (env *Environment) GetFiles(c *types.Config, hostPath string) error {
+	sshClient, err := newSSHClient(env.SSHPort, "root", EnvironmentRootPassword)
+	if err != nil {
+		return err
+	}
+	defer sshClient.Close()
+	for _, f := range c.Files {
+		if err := env.vmDownloadFile(sshClient, f, filepath.Join(hostPath, f)); err != nil {
+			return fmt.Errorf("cannot copy file %s: %s", f, err.Error())
+		}
+	}
+	for _, d := range c.Dirs {
+		if err := env.vmDownloadDir(sshClient, d, hostPath); err != nil {
+			return err
+		}
+	}
+	for src := range c.MapDirs {
+		dir, pattern := filepath.Split(src)
+		err := env.vmWalk(dir, func(path string, mode os.FileMode, linktarget string) error {
+			envdir, filename := filepath.Split(path)
+			match, _ := filepath.Match(pattern, filename)
+			if match {
+				var reldir string
+				if envdir == "" {
+					reldir = ""
+				} else {
+					reldir, err = filepath.Rel(dir, envdir)
+					if err != nil {
+						return err
+					}
+				}
+				relpath := filepath.Join(dir, reldir, filename)
+				destpath := filepath.Join(hostPath, relpath)
+				if mode.IsDir() {
+					return os.MkdirAll(destpath, 0755)
+				}
+				if (mode & os.ModeSymlink) == os.ModeSymlink {
+					return os.Symlink(linktarget, destpath)
+				}
+				return env.vmDownloadFile(sshClient, path, destpath)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if c.Program != "" {
+		err := env.vmDownloadFile(sshClient, c.Program, filepath.Join(hostPath, c.Program))
+		if err != nil {
+			return fmt.Errorf("cannot copy file %s: %s", c.Program, err.Error())
+		}
+		vmCmd := env.NewCommand("ldd " + c.Program).AsAdmin()
+		vmCmd.SuppressOutput = true
+		if err := vmCmd.Execute(); err != nil {
+			return err
+		}
+		sharedLibs := vmCmd.StdOutput()
+		for _, line := range strings.Split(sharedLibs, "\n") {
+			lineFields := strings.Fields(line)
+			for _, field := range lineFields {
+				if field[0] == '/' {
+					err := env.vmDownloadFile(sshClient, field, filepath.Join(hostPath, field))
+					if err != nil {
+						errString := fmt.Sprintf("cannot copy file %s: %s", field, err.Error())
+						return errors.New(errString)
+					}
+					break
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// Shutdown stops the environment VM, if running.
+func (env *Environment) Shutdown() error {
+	vmCmd := env.NewCommand("shutdown", "-hP", "now").AsAdmin()
+	err := vmCmd.Execute()
+	env.PID = 0
+	return err
+}
+
+// Uninstall uninstalls the environment from the system.
+func (env *Environment) Uninstall() error {
+	imageFilePath := filepath.Join(EnvironmentImageDirPath, env.ID+EnvironmentImageFileExtension)
+	return os.Remove(imageFilePath)
+}
+
+// NewEmptyCommand creates an empty command.
+func (env *Environment) NewEmptyCommand() *EnvironmentCommand {
+	return &EnvironmentCommand{
+		Username: EnvironmentUsername,
+		Password: EnvironmentUserPassword,
+		Port:     env.SSHPort,
+	}
+}
+
+// NewCommand creates new command to be executed via SSH.
+func (env *Environment) NewCommand(command string, args ...interface{}) *EnvironmentCommand {
+	vmCmd := env.NewEmptyCommand()
+	vmCmd.CommandLines = []string{
+		formatCommand(command, args...),
+	}
+	return vmCmd
+}
+
+// NewCommandf creates new formatted command to be executed via SSH.
+func (env *Environment) NewCommandf(format string, args ...interface{}) *EnvironmentCommand {
+	return env.NewCommand(fmt.Sprintf(format, args...))
+}
+
+// Downloads file from srcpath in VM to local filesystem.
+func (env *Environment) vmDownloadFile(client *ssh.Client, srcpath, destpath string) error {
+	log.Debugf("Copying file from remote %s to local %s", srcpath, destpath)
+	scpClient, err := scp.NewClientBySSH(client)
+	if err != nil {
+		return err
+	}
+	defer scpClient.Close()
+	if err := os.MkdirAll(filepath.Dir(destpath), 0755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(destpath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return scpClient.CopyFromRemote(file, srcpath)
+}
+
+// Downloads a directory (recursively) from srcpath in VM to local filesystem.
+func (env *Environment) vmDownloadDir(client *ssh.Client, srcpath, destpath string) error {
+	log.Debugf("Copying directory from remote %s to local %s", srcpath, destpath)
+	return env.vmWalk(srcpath, func(envpath string, mode os.FileMode, linktarget string) error {
+		hostpath := filepath.Join(destpath, envpath)
+		if mode.IsDir() {
+			return os.MkdirAll(hostpath, 0755)
+		}
+		if (mode & os.ModeSymlink) == os.ModeSymlink {
+			return os.Symlink(linktarget, hostpath)
+		}
+		return env.vmDownloadFile(client, envpath, hostpath)
+	})
+}
+
+func (env *Environment) vmWalk(dir string, fn vmWalkFunc) error {
+	vmCmd := env.NewCommand("ls -Al " + dir).AsAdmin()
+	vmCmd.SuppressOutput = true
+	if err := vmCmd.Execute(); err != nil {
+		return err
+	}
+	if err := fn(dir, os.ModeDir, ""); err != nil {
+		return err
+	}
+	dirContents := vmCmd.StdOutput()
+	for _, line := range strings.Split(dirContents, "\n") {
+		if line == "" {
+			continue
+		}
+		var mode os.FileMode
+		linktarget := ""
+		lineFields := strings.Fields(line)
+		nameEnd := len(lineFields)
+		switch line[0] {
+		case '-':
+		case 'd':
+			mode = os.ModeDir
+		case 'l':
+			mode = os.ModeSymlink
+			for linkSep, field := range lineFields {
+				if field == "->" {
+					nameEnd = linkSep
+					break
+				}
+			}
+			linktarget = strings.Join(lineFields[nameEnd+1:], " ")
+		default:
+			continue
+		}
+		name := filepath.Join(dir, strings.Join(lineFields[8:nameEnd], " "))
+		if mode == os.ModeDir {
+			if err := env.vmWalk(name, fn); err != nil {
+				return err
+			}
+		} else {
+			if err := fn(name, mode, linktarget); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type vmWalkFunc func(path string, mode os.FileMode, linktarget string) error
+
+// Creates a new SSH client using the given port and credentials.
+func newSSHClient(port int, username, password string) (*ssh.Client, error) {
+	return ssh.Dial("tcp", fmt.Sprintf("localhost:%v", port), &ssh.ClientConfig{
+		User: username,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+}

--- a/crossbuild/env_command.go
+++ b/crossbuild/env_command.go
@@ -1,0 +1,92 @@
+package crossbuild
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// EnvironmentCommand is one or more command lines to be executed.
+type EnvironmentCommand struct {
+	SuppressOutput bool
+	CommandLines   []string
+	Username       string
+	Password       string
+	Port           int
+	OutputBuffer   bytes.Buffer
+	ErrorBuffer    bytes.Buffer
+	currentSession *ssh.Session
+}
+
+// StdOutput returns the string written to the standard output stream by a command.
+func (cmd *EnvironmentCommand) StdOutput() string {
+	return cmd.OutputBuffer.String()
+}
+
+// StdError returns the string written to the standard error stream by a command.
+func (cmd *EnvironmentCommand) StdError() string {
+	return cmd.ErrorBuffer.String()
+}
+
+// Execute executes command in VM as regular user, or as admin if asAdmin is true.
+func (cmd *EnvironmentCommand) Execute() error {
+	client, err := newSSHClient(cmd.Port, cmd.Username, cmd.Password)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	for _, cmdLine := range cmd.CommandLines {
+		if err := cmd.executeCommand(client, cmdLine); err != nil {
+			if cmd.SuppressOutput {
+				return errors.New(strings.TrimSpace(cmd.StdError()))
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// Then appends command line to the set of commands.
+func (cmd *EnvironmentCommand) Then(command string, args ...interface{}) *EnvironmentCommand {
+	cmd.CommandLines = append(cmd.CommandLines, formatCommand(command, args...))
+	return cmd
+}
+
+// AsAdmin modifies the command to use admin account.
+func (cmd *EnvironmentCommand) AsAdmin() *EnvironmentCommand {
+	cmd.Username = "root"
+	cmd.Password = EnvironmentRootPassword
+	return cmd
+}
+
+// Executes a single command line.
+func (cmd *EnvironmentCommand) executeCommand(client *ssh.Client, cmdLine string) error {
+	session, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	cmd.currentSession = session
+	session.Stdin = os.Stdin
+	if cmd.SuppressOutput {
+		session.Stdout = &cmd.OutputBuffer
+		session.Stderr = &cmd.ErrorBuffer
+	} else {
+		session.Stdout = io.MultiWriter(os.Stdout, &cmd.OutputBuffer)
+		session.Stderr = io.MultiWriter(os.Stderr, &cmd.ErrorBuffer)
+	}
+	return session.Run(cmdLine)
+}
+
+// Formats command and arguments as a single string.
+func formatCommand(command string, args ...interface{}) string {
+	line := []interface{}{command}
+	line = append(line, args...)
+	return fmt.Sprintln(line...)
+}

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -60,6 +60,9 @@ func (m *Manifest) AddUserProgram(imgpath string) (err error) {
 	}
 	program := path.Join("/", path.Join(parts...))
 
+	if filepath.IsAbs(imgpath) {
+		imgpath = filepath.Join(m.targetRoot, imgpath)
+	}
 	err = m.AddFile(program, imgpath)
 	if err != nil {
 		return
@@ -153,6 +156,13 @@ func (m *Manifest) AddDirectory(dir string, workDir string) error {
 		return err
 	}
 
+	var absPath bool
+	if filepath.IsAbs(dir) {
+		dir = filepath.Join(m.targetRoot, dir)
+		absPath = true
+	} else {
+		absPath = false
+	}
 	err := filepath.Walk(dir, func(hostpath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -160,7 +170,9 @@ func (m *Manifest) AddDirectory(dir string, workDir string) error {
 
 		// if the path is relative then root it to image path
 		var vmpath string
-		if hostpath[0] != '/' {
+		if absPath {
+			vmpath = strings.TrimPrefix(hostpath, m.targetRoot)
+		} else if hostpath[0] != '/' {
 			vmpath = "/" + hostpath
 		} else {
 			vmpath = hostpath

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/UpCloudLtd/upcloud-go-api v0.0.0-20210127073406-2964ed7e5972
 	github.com/aws/aws-sdk-go v1.35.20
+	github.com/bramvdbogaerde/go-scp v1.0.0
 	github.com/containerd/containerd v1.5.2 // indirect
 	github.com/digitalocean/godo v1.57.0
 	github.com/docker/distribution v2.7.1+incompatible
@@ -41,10 +42,12 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/terra-farm/go-virtualbox v0.0.4
+	github.com/tj/go-spin v1.1.0
 	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	github.com/vmware/govmomi v0.22.2
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd
-	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
+	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
 	google.golang.org/api v0.30.0
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bramvdbogaerde/go-scp v1.0.0 h1:YWfdc1H6TDNgXMnvNYTa+NDvQpV6Q4kyImWBfLDyJ6w=
+github.com/bramvdbogaerde/go-scp v1.0.0/go.mod h1:s4ZldBoRAOgUg8IrRP2Urmq5qqd2yPXQTPshACY8vQ0=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -672,6 +674,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/terra-farm/go-virtualbox v0.0.4 h1:UAEVNAYLA3g80Z//fMZFVSWHEPqRWkWP2gmFh2p/guQ=
 github.com/terra-farm/go-virtualbox v0.0.4/go.mod h1:5n2X+HKR2eAzHfuGFnrZlCrgiYrseNHIcNTSpA/ViyU=
+github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
+github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
@@ -737,6 +741,8 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -900,6 +906,8 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea h1:+WiDlPBBaO+h9vPNZi8uJ3k4BkKQB7Iow3aqwHVA5hI=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -248,7 +248,12 @@ func setManifestFromConfig(m *fs.Manifest, c *types.Config) error {
 	}
 
 	for k, v := range c.MapDirs {
-		err := addMappedFiles(k, v, c.LocalFilesParentDirectory, m)
+		if filepath.IsAbs(k) {
+			k = filepath.Join(c.TargetRoot, k)
+		} else {
+			k = filepath.Join(c.LocalFilesParentDirectory, k)
+		}
+		err := addMappedFiles(k, v, m)
 		if err != nil {
 			return err
 		}
@@ -353,7 +358,7 @@ func BuildManifest(c *types.Config) (*fs.Manifest, error) {
 	return m, nil
 }
 
-func addMappedFiles(src string, dest string, workDir string, m *fs.Manifest) error {
+func addMappedFiles(src string, dest string, m *fs.Manifest) error {
 	dir, pattern := filepath.Split(src)
 	err := filepath.Walk(dir, func(hostpath string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/lepton/ldd_darwin.go
+++ b/lepton/ldd_darwin.go
@@ -53,17 +53,18 @@ func expandVars(origin string, s string) string {
 
 func findLib(targetRoot string, origin string, libDirs []string, path string) (string, error) {
 	if path[0] == '/' {
-		if _, err := fs.LookupFile(targetRoot, path); err != nil {
+		rpath, err := fs.LookupFile(targetRoot, path)
+		if err != nil {
 			return "", err
 		}
-		return path, nil
+		return rpath, nil
 	}
 
 	for _, libDir := range libDirs {
 		lib := filepath.Join(expandVars(origin, libDir), path)
-		_, err := fs.LookupFile(targetRoot, lib)
+		rlib, err := fs.LookupFile(targetRoot, lib)
 		if err == nil {
-			return lib, nil
+			return rlib, nil
 		} else if !os.IsNotExist(err) {
 			return "", err
 		}

--- a/qemu/qemu_components.go
+++ b/qemu/qemu_components.go
@@ -15,7 +15,10 @@ type drive struct {
 
 func (d drive) String() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("-drive file=%s,format=%s", d.path, d.format))
+	sb.WriteString(fmt.Sprintf("-drive file=%s", d.path))
+	if len(d.format) > 0 {
+		sb.WriteString(fmt.Sprintf(",format=%s", d.format))
+	}
 	if len(d.index) > 0 {
 		sb.WriteString(fmt.Sprintf(",index=%s", d.index))
 	}

--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -96,9 +96,12 @@ func (q *qemu) Start(rconfig *types.RunConfig) error {
 func (q *qemu) addDrive(id, image, ifaceType string) {
 	drv := drive{
 		path:   image,
-		format: "raw",
 		iftype: ifaceType,
 		ID:     id,
+	}
+	fileExt := filepath.Ext(image)
+	if !strings.Contains(fileExt, "qcow") {
+		drv.format = "raw"
 	}
 	q.drives = append(q.drives, drv)
 }
@@ -314,7 +317,9 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) {
 		q.addOption("-device", "virtio-scsi-pci,bus=pci.2,addr=0x0,id=scsi0")
 		q.addOption("-device", "scsi-hd,bus=scsi0.0,drive=hd0")
 
-		q.addOption("-vga", "none")
+		if !rconfig.Vga {
+			q.addOption("-vga", "none")
+		}
 
 		if rconfig.CPUs > 0 {
 			q.addOption("-smp", strconv.Itoa(rconfig.CPUs))

--- a/types/config.go
+++ b/types/config.go
@@ -214,6 +214,9 @@ type RunConfig struct {
 	// signify a value in megabytes or gigabytes respectively.
 	Memory string
 
+	// Vga whether to emulate a VGA output device
+	Vga bool
+
 	// Mounts
 	Mounts []string
 


### PR DESCRIPTION
This PR adds the 'env' set of commands, which allows to build an application in a Linux virtual machine and create a Nanos image from a set of files retrieved from the Linux virtual machine.
Usage summary for the new commands:
- `ops env install`: downloads a VM image from an online repository and extracts it in $OPS_HOME/crossbuild/images
- `ops env uninstall`: removes the VM image from $OPS_HOME/crossbuild/images
- `ops env build <build_file> --create-image -c config.json`: starts the build VM, connects to it via ssh, executes in sequence the set of commands specified in <build_file> (aborting the process if any of those commands returns an error), then reads any "Files", "Dirs" and "MapDirs" directives in config.json (which is a standard ops configuration file), copies the relevant files in a temporary folder in the host and uses them to create an on-prem image; finally, the build VM is stopped
- `ops env build <build_file> -r <host_path> -c config.json`: like above, but instead of copying the files in a temporary folder copies them into <host_path>, and does not create an image; the set of files copied in <host_path> can then be used to create any image the user may want (on-prem or otherwise); this is useful if the user wants to modify the set of files and/or add new files before creating an image
- `ops env copy <host_path> -c config.json`: like above, but without the build step; this is useful if the user wants to create
different images with different sets of files, and doesn't need to repeat the build step every time