### PR TITLE
Use UDPPorts with qemu instead of UDP bool

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -119,7 +119,7 @@ func (q *qemu) addSerial(serialType string) {
 // added. If the mac address is empty then a random mac address is chosen.
 // Backend interface are created for each device and their ids are auto
 // incremented.
-func (q *qemu) addNetDevice(devType, ifaceName, mac string, hostPorts []string, udp bool) {
+func (q *qemu) addNetDevice(devType, ifaceName, mac string, hostPorts []string, udpPorts []string) {
 	id := fmt.Sprintf("n%d", len(q.ifaces))
 	dv := device{
 		driver:  "virtio-net",
@@ -140,10 +140,9 @@ func (q *qemu) addNetDevice(devType, ifaceName, mac string, hostPorts []string, 
 	} else {
 		for _, p := range hostPorts {
 			ndv.hports = append(ndv.hports, portfwd{port: p, proto: "tcp"})
-
-			if udp {
-				ndv.hports = append(ndv.hports, portfwd{port: p, proto: "udp"})
-			}
+		}
+		for _, p := range udpPorts {
+			ndv.hports = append(ndv.hports, portfwd{port: p, proto: "udp"})
 		}
 	}
 
@@ -358,7 +357,7 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) {
 
 	q.setAccel(rconfig)
 
-	q.addNetDevice(netDevType, ifaceName, "", rconfig.Ports, rconfig.UDP)
+	q.addNetDevice(netDevType, ifaceName, "", rconfig.Ports, rconfig.UDPPorts)
 	q.addDisplay("none")
 
 	if rconfig.Background {

--- a/qemu/qemu_unix_test.go
+++ b/qemu/qemu_unix_test.go
@@ -73,7 +73,7 @@ func TestStringSerial(t *testing.T) {
 
 func TestRandomMacGen(t *testing.T) {
 	q := qemu{}
-	q.addNetDevice("tap", "tap0", "", []string{}, false)
+	q.addNetDevice("tap", "tap0", "", []string{}, []string{})
 	if len(q.devices[0].mac) == 0 {
 		t.Errorf("No RandomMac was assigned %s", q.devices[0].mac)
 	}
@@ -83,7 +83,7 @@ func TestAddNetDevices(t *testing.T) {
 
 	t.Run("should add a port forward per tcp port", func(t *testing.T) {
 		q := qemu{}
-		q.addNetDevice("user", "", "", []string{"80", "8080", "9000"}, false)
+		q.addNetDevice("user", "", "", []string{"80", "8080", "9000"}, []string{})
 
 		want := []portfwd{
 			{port: "80", proto: "tcp"},
@@ -99,7 +99,7 @@ func TestAddNetDevices(t *testing.T) {
 
 	t.Run("should add a port forward range", func(t *testing.T) {
 		q := qemu{}
-		q.addNetDevice("user", "", "", []string{"80-9000"}, false)
+		q.addNetDevice("user", "", "", []string{"80-9000"}, []string{})
 
 		want := []portfwd{
 			{port: "80-9000", proto: "tcp"},

--- a/types/config.go
+++ b/types/config.go
@@ -245,9 +245,6 @@ type RunConfig struct {
 	// TapName
 	TapName string
 
-	// UDP specifies if the UDP protocol is enabled (default is false).
-	UDP bool
-
 	// UDPPorts
 	UDPPorts []string
 


### PR DESCRIPTION
All the cloud providers use UDPPorts to specify open udp ports, but qemu
used a UDP bool to determine if Ports should also open udp ports. This change
removes the UDP bool from the config and switches qemu to use UDPPorts
instead.