### PR TITLE
AWS volume create: avoid uploading large files to S3 

### DIFF
--- a/aws/aws_volume.go
+++ b/aws/aws_volume.go
@@ -16,11 +16,11 @@ var (
 )
 
 // CreateVolume creates a snapshot and use it to create a volume
-func (a *AWS) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (a *AWS) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	config := ctx.Config()
 
 	// Create volume
-	vol, err := lepton.CreateLocalVolume(config, name, data, size, provider)
+	vol, err := lepton.CreateLocalVolume(config, name, data, provider)
 	if err != nil {
 		return vol, fmt.Errorf("create local volume: %v", err)
 	}

--- a/azure/azure_volume.go
+++ b/azure/azure_volume.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateVolume uploads the volume raw file and creates a disk from it
-func (a *Azure) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (a *Azure) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	config := ctx.Config()
 
 	var vol lepton.NanosVolume
@@ -26,12 +26,12 @@ func (a *Azure) CreateVolume(ctx *lepton.Context, name, data, size, provider str
 
 	location := a.getLocation(config)
 
-	sizeInt, err := strconv.Atoi(size)
+	sizeInGb, err := lepton.GetSizeInGb(config.BaseVolumeSz)
 	if err != nil {
 		return vol, err
 	}
 
-	vol, err = lepton.CreateLocalVolume(config, name, data, size, provider)
+	vol, err = lepton.CreateLocalVolume(config, name, data, provider)
 	if err != nil {
 		return vol, fmt.Errorf("create local volume: %v", err)
 	}
@@ -59,7 +59,7 @@ func (a *Azure) CreateVolume(ctx *lepton.Context, name, data, size, provider str
 		Name:     to.StringPtr(name),
 		DiskProperties: &compute.DiskProperties{
 			HyperVGeneration: compute.V1,
-			DiskSizeGB:       to.Int32Ptr(int32(sizeInt / 1000 / 1000)),
+			DiskSizeGB:       to.Int32Ptr(int32(sizeInGb)),
 			CreationData: &compute.CreationData{
 				CreateOption:     "Import",
 				SourceURI:        to.StringPtr(sourceURI),

--- a/cmd/cmd_volume.go
+++ b/cmd/cmd_volume.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"log"
-	"strconv"
 
 	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/types"
 
 	api "github.com/nanovms/ops/lepton"
-	"github.com/nanovms/ops/onprem"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +43,7 @@ func volumeCreateCommand() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 	}
 	cmdVolumeCreate.PersistentFlags().StringVarP(&data, "data", "d", "", "volume data source")
-	cmdVolumeCreate.PersistentFlags().StringVarP(&size, "size", "s", strconv.Itoa(onprem.MinimumVolumeSize), "volume initial size")
+	cmdVolumeCreate.PersistentFlags().StringVarP(&size, "size", "s", "", "volume initial size")
 	return cmdVolumeCreate
 }
 
@@ -58,13 +56,16 @@ func volumeCreateCommandHandler(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError(err.Error())
 	}
+	if size != "" {
+		c.BaseVolumeSz = size
+	}
 
 	p, ctx, err := getProviderAndContext(c, c.CloudConfig.Platform)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	res, err := p.CreateVolume(ctx, name, data, size, c.CloudConfig.Platform)
+	res, err := p.CreateVolume(ctx, name, data, c.CloudConfig.Platform)
 	if err != nil {
 		exitWithError(err.Error())
 	}

--- a/digitalocean/digital_ocean_volume.go
+++ b/digitalocean/digital_ocean_volume.go
@@ -3,7 +3,7 @@ package digitalocean
 import "github.com/nanovms/ops/lepton"
 
 // CreateVolume is a stub to satisfy VolumeService interface
-func (do *DigitalOcean) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (do *DigitalOcean) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	var vol lepton.NanosVolume
 	return vol, nil
 }

--- a/gcp/gcp_volume.go
+++ b/gcp/gcp_volume.go
@@ -13,12 +13,12 @@ import (
 )
 
 // CreateVolume creates local volume and converts it to GCP format before orchestrating the necessary upload procedures
-func (g *GCloud) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (g *GCloud) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	config := ctx.Config()
 
 	arch := name + ".tar.gz"
 
-	lv, err := lepton.CreateLocalVolume(config, name, data, size, provider)
+	lv, err := lepton.CreateLocalVolume(config, name, data, provider)
 	if err != nil {
 		return lv, err
 	}

--- a/hyperv/hyperv.go
+++ b/hyperv/hyperv.go
@@ -38,7 +38,7 @@ func (p *Provider) Initialize(c *types.ProviderConfig) error {
 }
 
 // CreateVolume is a stub
-func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	return lepton.NanosVolume{}, errors.New("Unsupported")
 }
 

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -61,7 +61,7 @@ type Storage interface {
 
 // VolumeService is an interface for volume related operations
 type VolumeService interface {
-	CreateVolume(ctx *Context, name, data, size, provider string) (NanosVolume, error)
+	CreateVolume(ctx *Context, name, data, provider string) (NanosVolume, error)
 	GetAllVolumes(ctx *Context) (*[]NanosVolume, error)
 	DeleteVolume(ctx *Context, name string) error
 	AttachVolume(ctx *Context, image, name string) error

--- a/oci/oci_volume.go
+++ b/oci/oci_volume.go
@@ -10,17 +10,16 @@ import (
 )
 
 // CreateVolume creates a local volume and uploads the volume to oci
-func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (vol lepton.NanosVolume, err error) {
+func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, provider string) (vol lepton.NanosVolume, err error) {
 	return lepton.NanosVolume{}, errors.New("Unsupported")
 
-	sizeInBs, err := strconv.Atoi(size)
+	size, err := lepton.GetSizeInGb(ctx.Config().BaseVolumeSz)
 	if err != nil {
 		ctx.Logger().Log(err.Error())
 		err = errors.New("failed converting size to number")
 		return
 	}
-
-	sizeInGBs := int64(sizeInBs / 1024 / 1024)
+	sizeInGBs := int64(size)
 
 	if sizeInGBs < 50 {
 		sizeInGBs = 50

--- a/onprem/onprem_volume.go
+++ b/onprem/onprem_volume.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/nanovms/ops/lepton"
@@ -18,8 +19,12 @@ const (
 )
 
 // CreateVolume creates volume for onprem image
-func (op *OnPrem) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
-	return lepton.CreateLocalVolume(ctx.Config(), name, data, size, provider)
+func (op *OnPrem) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
+	c := ctx.Config()
+	if c.BaseVolumeSz == "" {
+		c.BaseVolumeSz = strconv.Itoa(MinimumVolumeSize)
+	}
+	return lepton.CreateLocalVolume(c, name, data, provider)
 }
 
 // GetAllVolumes prints list of all onprem nanos-managed volumes

--- a/onprem/onprem_volume_test.go
+++ b/onprem/onprem_volume_test.go
@@ -65,7 +65,7 @@ func TestOnPremVolume(t *testing.T) {
 
 func testCreateVolume(t *testing.T, name string, vol *lepton.NanosVolume, count *int) {
 	t.Run(fmt.Sprintf("create_%s", name), func(t *testing.T) {
-		res, err := testOP.CreateVolume(NewTestContext(testVolumeConfig), vol.Name, vol.Data, vol.Size, "onprem")
+		res, err := testOP.CreateVolume(NewTestContext(testVolumeConfig), vol.Name, vol.Data, "onprem")
 		if err != nil {
 			t.Error(err)
 			return

--- a/upcloud/upcloud_volume.go
+++ b/upcloud/upcloud_volume.go
@@ -13,8 +13,8 @@ import (
 )
 
 // CreateVolume creates a local volume and uploads the volume to upcloud
-func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (vol lepton.NanosVolume, err error) {
-	vol, err = lepton.CreateLocalVolume(ctx.Config(), name, data, size, provider)
+func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, provider string) (vol lepton.NanosVolume, err error) {
+	vol, err = lepton.CreateLocalVolume(ctx.Config(), name, data, provider)
 	if err != nil {
 		return
 	}

--- a/vbox/vbox_volume.go
+++ b/vbox/vbox_volume.go
@@ -8,8 +8,8 @@ import (
 )
 
 // CreateVolume creates a local volume and uploads the volume to upcloud
-func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (vol lepton.NanosVolume, err error) {
-	vol, err = lepton.CreateLocalVolume(ctx.Config(), name, data, size, provider)
+func (p *Provider) CreateVolume(ctx *lepton.Context, name, data, provider string) (vol lepton.NanosVolume, err error) {
+	vol, err = lepton.CreateLocalVolume(ctx.Config(), name, data, provider)
 	if err != nil {
 		return
 	}

--- a/vsphere/vsphere_volume.go
+++ b/vsphere/vsphere_volume.go
@@ -17,11 +17,11 @@ import (
 )
 
 // CreateVolume converts local volume raw file to mkfs and uploads required files to datastore
-func (v *Vsphere) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (v *Vsphere) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	config := ctx.Config()
 	var vol lepton.NanosVolume
 
-	vol, err := lepton.CreateLocalVolume(config, name, data, size, provider)
+	vol, err := lepton.CreateLocalVolume(config, name, data, provider)
 	if err != nil {
 		return vol, err
 	}

--- a/vultr/vultr_volume.go
+++ b/vultr/vultr_volume.go
@@ -3,7 +3,7 @@ package vultr
 import "github.com/nanovms/ops/lepton"
 
 // CreateVolume is a stub to satisfy VolumeService interface
-func (v *Vultr) CreateVolume(ctx *lepton.Context, name, data, size, provider string) (lepton.NanosVolume, error) {
+func (v *Vultr) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
 	var vol lepton.NanosVolume
 	return vol, nil
 }


### PR DESCRIPTION
The AWS volume create implementation first uploads to S3 a locally created volume, then creates a snapshot from the uploaded file, and finally creates a volume from the shapshot. When a volume is created from a snapshot, it is possible to specify a size parameter (which must be larger than or equal to the size of the snapshot): this allows to create arbitrarily sized volumes from small snapshots.
This commit changes the AWS volume create implementation so that the volume file being uploaded to S3 is created with the minimum size needed for the filesystem, and any volume size specified by the user is passed to the AWS volume creation API command.