### PR TITLE
Fix Mac dependency generation for dynamic executables

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -368,16 +368,6 @@ func (m *Manifest) AddFileTo(dir map[string]interface{}, filepath string, hostpa
 	return nil
 }
 
-// AddLibrary to add a dependent library
-func (m *Manifest) AddLibrary(path string) {
-	parts := strings.FieldsFunc(strings.TrimPrefix(path, m.targetRoot), func(c rune) bool { return c == '/' })
-	node := m.rootDir()
-	for i := 0; i < len(parts)-1; i++ {
-		node = mkDir(node, parts[i])
-	}
-	m.AddFileTo(node, parts[len(parts)-1], path)
-}
-
 // AddPassthrough to add key, value directly to manifest
 func (m *Manifest) AddPassthrough(key string, value interface{}) {
 	m.root[key] = value

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -344,8 +344,8 @@ func BuildManifest(c *types.Config) (*fs.Manifest, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, 1)
 	}
-	for _, libpath := range deps {
-		m.AddLibrary(libpath)
+	for libpath, hostpath := range deps {
+		m.AddFile(libpath, hostpath)
 	}
 
 	if c.RunConfig.IPAddress != "" || c.RunConfig.IPv6Address != "" {

--- a/lepton/ldd_linux.go
+++ b/lepton/ldd_linux.go
@@ -47,7 +47,7 @@ func IsDynamicLinked(efd *elf.File) bool {
 
 // works only on linux, need to
 // replace looking up in dynamic section in ELF
-func getSharedLibs(targetRoot string, path string) ([]string, error) {
+func getSharedLibs(targetRoot string, path string) (map[string]string, error) {
 	var notExistLib []string
 	var absTargetRoot string
 	if targetRoot != "" {
@@ -75,7 +75,7 @@ func getSharedLibs(targetRoot string, path string) ([]string, error) {
 	// LD_TRACE_LOADED_OBJECTS need to fork with out executing it.
 	// TODO:move away from LD_TRACE_LOADED_OBJECTS
 	dir, _ := os.Getwd()
-	var deps []string
+	var deps = make(map[string]string)
 
 	elfFile, err := GetElfFileInfo(path)
 
@@ -117,7 +117,8 @@ func getSharedLibs(targetRoot string, path string) ([]string, error) {
 				notExistLib = append(notExistLib, text)
 			}
 			err = errors.New("")
-			deps = append(deps, strings.TrimSpace(libpath))
+			libpath = strings.TrimSpace(libpath)
+			deps[strings.TrimPrefix(libpath, absTargetRoot)] = libpath
 		}
 
 		if len(notExistLib) != 0 {

--- a/lepton/ldd_windows.go
+++ b/lepton/ldd_windows.go
@@ -21,7 +21,7 @@ func GetElfFileInfo(path string) (*elf.File, error) {
 }
 
 // stub
-func getSharedLibs(targetRoot string, path string) ([]string, error) {
-	var deps []string
+func getSharedLibs(targetRoot string, path string) (map[string]string, error) {
+	var deps = make(map[string]string)
 	return deps, nil
 }


### PR DESCRIPTION
The getSharedLibs list generated by the Mac was not including the dynamic
loader so a dynamically-linked executable could not even start. The loader
location in the target root distribution is actually a symlink with an absolute
path, which revealed another problem in that absolute symlinks for libraries
were getting placed in the image at the location of the link target rather than
at the location of the symlink. This necessitated changing getSharedLibs to
return a map of string pairs so that the image path could be different
from the host file location. This also lets us remove AddLibrary since the
image path and host path no longer need to be calculated from a single string.