### PR TITLE
AWS subnet: add availability zone from cloud config

### DIFF
--- a/aws/aws_network.go
+++ b/aws/aws_network.go
@@ -129,8 +129,9 @@ func (p *AWS) CreateSubnet(ctx *lepton.Context, vpc *ec2.Vpc) (subnet *ec2.Subne
 	tags, _ := buildAwsTags([]types.Tag{}, ctx.Config().CloudConfig.Subnet)
 
 	createSubnetInput := &ec2.CreateSubnetInput{
-		VpcId:     vpc.VpcId,
-		CidrBlock: vpc.CidrBlock,
+		AvailabilityZone: aws.String(ctx.Config().CloudConfig.Zone),
+		VpcId:            vpc.VpcId,
+		CidrBlock:        vpc.CidrBlock,
 		TagSpecifications: []*ec2.TagSpecification{
 			{Tags: tags, ResourceType: aws.String("subnet")},
 		},


### PR DESCRIPTION
When an AWS subnet is created, it is tied to a specific availability zone, and this determines the zone of any instances that are subsequently created using this subnet.
This change adds the user-provided availability zone to the set of parameters used when creating a subnet, so that instances created by Ops are deployed in the expected availability zone.
Note: if no new subnet is created when creating an instance (such as when a default subnet already exists and the user doesn't specify a VPC and subnet in the cloud config), instances are still deployed in the availability zone of the existing subnet, which might be different from the zone specified in the cloud config.