### PR TITLE
Vultr: error if no zone is set

### DIFF
--- a/vultr/vultr_instance.go
+++ b/vultr/vultr_instance.go
@@ -21,6 +21,10 @@ func (v *Vultr) CreateInstance(ctx *lepton.Context) error {
 		flavor = c.CloudConfig.Flavor
 	}
 
+	if c.CloudConfig.Zone == "" {
+		return fmt.Errorf("zone is required (-z)")
+	}
+
 	instance, err := v.Client.Instance.Create(context.TODO(), &govultr.InstanceCreateReq{
 		Region:     c.CloudConfig.Zone,
 		Plan:       flavor,


### PR DESCRIPTION
Since the API response isn't very helpful:

Before:
```
» ~/ops instance create dceda686-9f2c-4b49-8e9d-f82b9ca36712 -t vultr
{"error":"Bad request.","status":400}
```

After:
```
» ~/ops instance create dceda686-9f2c-4b49-8e9d-f82b9ca36712 -t vultr
zone is required (-z)
```