### PR TITLE
DO: check if bucket exists when creating image

### DIFF
--- a/digitalocean/digital_ocean_store.go
+++ b/digitalocean/digital_ocean_store.go
@@ -64,6 +64,18 @@ func (s *Spaces) CopyToBucket(config *types.Config, archPath string) error {
 	}
 
 	bucket := config.CloudConfig.BucketName
+	if bucket == "" {
+		log.Fatal(fmt.Errorf("BucketName is required"))
+	}
+
+	bucketExists, err := client.BucketExists(bucket)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !bucketExists {
+		log.Fatal(fmt.Errorf("bucket %s does not exist", bucket))
+	}
+
 	key := filepath.Base(archPath)
 
 	n, err := client.PutObject(bucket, key, file, stat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream"})


### PR DESCRIPTION
Fix for https://github.com/nanovms/ops/issues/1037

```
» ~/ops image create -i spring-boot-hello --package java_1.8.0_191 -c config.json -t do
 100% |████████████████████████████████████████|  [0s:0s]
BucketName is required
```

After defined the bucket name in the config:

```
» ~/ops image create -i spring-boot-hello --package java_1.8.0_191 -c config.json -t do
 100% |████████████████████████████████████████|  [0s:0s]
bucket nanowg2 does not exist
```