### PR TITLE
improve dev ux of error and change panic log to error log

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -105,7 +105,8 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 		packages, err = api.GetPackageList(lepton.NewConfig())
 	}
 	if err != nil {
-		log.Panicf("failed getting packages: %s", err)
+		log.Errorf("failed getting packages: %s", err)
+		return
 	}
 
 	searchRegex, err := cmd.Flags().GetString("search")

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -559,7 +559,7 @@ func DownloadFile(filepath string, url string, timeout int, showProgress bool) e
 
 	if resp.StatusCode != 200 {
 		os.Remove(out.Name())
-		return errors.New("resource not found")
+		return fmt.Errorf("can not download file from: %s, status: %s", url, resp.Status)
 	}
 
 	fsize, _ := strconv.Atoi(resp.Header.Get("Content-Length"))


### PR DESCRIPTION
This error does not give developer any useful information, and it is unnecessary panic.

`ops pkg list
`

failed getting packages: resource not found
panic: failed getting packages: resource not found


goroutine 1 [running]:
github.com/nanovms/ops/log.Panicf({0x24088fc, 0x1b}, {0xc0007bfc88, 0x1, 0x1})
	/home/divar/Tutorial/Unikernel/nanovm/ops/log/logger_default.go:91 +0x108
github.com/nanovms/ops/cmd.cmdListPackages(0xc0004e7080, {0x3a42160, 0x0, 0x0})
	/home/divar/Tutorial/Unikernel/nanovm/ops/cmd/cmd_pkg.go:108 +0xa9
github.com/spf13/cobra.(*Command).execute(0xc0004e7080, {0x3a42160, 0x0, 0x0})
	/home/divar/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc00022f340)
	/home/divar/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
	/home/divar/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/home/divar/Tutorial/Unikernel/nanovm/ops/ops.go:8 +0x1e

======================

Error output example, after the pull request changes:
failed getting packages: can not download file from: https://storage.googleapis.com/packagehub/manifest.json, status: 403 Forbidden

This way, it is easier to find the problem.