### PR TITLE
run command: add option to specify RAM size

### DIFF
--- a/cmd/flags_run_local_instance.go
+++ b/cmd/flags_run_local_instance.go
@@ -27,6 +27,7 @@ type RunLocalInstanceCommandFlags struct {
 	NoTrace        []string
 	Ports          []string
 	SkipBuild      bool
+	Memory         string
 	Smp            int
 	SyscallSummary bool
 	TapName        string
@@ -74,6 +75,10 @@ func (flags *RunLocalInstanceCommandFlags) MergeToConfig(c *types.Config) error 
 
 	if flags.MissingFiles {
 		c.Debugflags = append(c.Debugflags, "missing_files")
+	}
+
+	if flags.Memory != "" {
+		c.RunConfig.Memory = flags.Memory
 	}
 
 	if flags.Smp > 0 {
@@ -205,6 +210,11 @@ func NewRunLocalInstanceCommandFlags(cmdFlags *pflag.FlagSet) (flags *RunLocalIn
 		exitWithError(err.Error())
 	}
 
+	flags.Memory, err = cmdFlags.GetString("memory")
+	if err != nil {
+		exitWithError(err.Error())
+	}
+
 	flags.Smp, err = cmdFlags.GetInt("smp")
 	if err != nil {
 		exitWithError(err.Error())
@@ -252,6 +262,7 @@ func PersistRunLocalInstanceCommandFlags(cmdFlags *pflag.FlagSet) {
 	cmdFlags.StringP("tapname", "t", "", "tap device name")
 	cmdFlags.BoolP("skipbuild", "s", false, "skip building image")
 	cmdFlags.Bool("accel", true, "use cpu virtualization extension")
+	cmdFlags.StringP("memory", "m", "", "RAM size")
 	cmdFlags.IntP("smp", "", 1, "number of threads to use")
 	cmdFlags.Bool("syscall-summary", false, "print syscall summary on exit")
 	cmdFlags.Bool("missing-files", false, "print list of files not found on image at exit")

--- a/cmd/flags_run_local_instance_test.go
+++ b/cmd/flags_run_local_instance_test.go
@@ -26,6 +26,7 @@ func TestCreateRunLocalInstanceFlags(t *testing.T) {
 	assert.Equal(t, runLocalInstanceFlags.TapName, "tap1")
 	assert.Equal(t, runLocalInstanceFlags.SkipBuild, true)
 	assert.Equal(t, runLocalInstanceFlags.Accel, false)
+	assert.Equal(t, runLocalInstanceFlags.Memory, "64M")
 	assert.Equal(t, runLocalInstanceFlags.Smp, 2)
 	assert.Equal(t, runLocalInstanceFlags.SyscallSummary, true)
 
@@ -52,6 +53,7 @@ func TestRunLocalInstanceFlagsMergeToConfig(t *testing.T) {
 				Accel:      true,
 				Bridged:    true,
 				BridgeName: "br1",
+				Memory:     "64M",
 				CPUs:       2,
 				Debug:      false,
 				GdbPort:    1234,
@@ -116,6 +118,7 @@ func newRunLocalInstanceFlagSet(debug string) *cmd.RunLocalInstanceCommandFlags 
 	flagSet.Set("skipbuild", "true")
 	flagSet.Set("manifest-name", "manifest.json")
 	flagSet.Set("accel", "true")
+	flagSet.Set("memory", "64M")
 	flagSet.Set("smp", "2")
 	flagSet.Set("mounts", "files:/mnt/f")
 	flagSet.Set("syscall-summary", "true")


### PR DESCRIPTION
With the '-m' (or '--memory') command line flag, the 'ops run' command assigns the specified amount of RAM to the local instance being run. The flag value uses the same syntax as the "RunConfig.Memory" attribute in the configuration file (e.g. "64M", or "4G"), and if present overrides the value in the configuration file.