### PR TITLE
Apple rebrands "OS X" as "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Build:
 make build
 ```
 
-osx notes:
+macOS notes:
 
 ```sh
 GO111MODULE=on go build -ldflags "-w"

--- a/lepton/ldd_darwin.go
+++ b/lepton/ldd_darwin.go
@@ -84,7 +84,7 @@ func _getSharedLibs(libs map[string]string, targetRoot string, path string) erro
 	fd, err := elf.Open(path)
 	if err != nil {
 		if strings.Contains(err.Error(), "bad magic number") {
-			log.Fatalf(constants.ErrorColor, "Only ELF binaries are supported. Is this a Mach-0 (osx) binary? run 'file "+path+"' on it\n")
+			log.Fatalf(constants.ErrorColor, "Only ELF binaries are supported. Is this a Mach-0 (macOS) binary? run 'file "+path+"' on it\n")
 		}
 		return errors.WrapPrefix(err, path, 0)
 	}


### PR DESCRIPTION
In 2012, with the release of OS X 10.8 Mountain Lion, the name of the
system was shortened from Mac OS X to OS X. In 2016, with the release
of macOS 10.12 Sierra, the name was changed from OS X to macOS to
streamline it with the branding of Apple's other primary operating
systems: iOS, watchOS, and tvOS.

Reference: https://en.wikipedia.org/wiki/MacOS