### PR TITLE
fix 'make run' command failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 	rm -f $(BINARY_NAME)
 
 run:
-	$(GOBUILD) -o $(BINARY_NAME) -v ./...
+	$(GOBUILD) -o $(BINARY_NAME) -v .
 	./$(BINARY_NAME)
 
 deps:


### PR DESCRIPTION
Currently running the `make run` commands fails with this error
```
make run
go build -o ops -v ./...
go build: cannot write multiple packages to non-directory ops
```
This PR fixes it. Verified the build binary works correctly.