### PR TITLE
Add an option to disable automatic args file copy

### DIFF
--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -15,16 +15,17 @@ import (
 
 // BuildImageCommandFlags consolidates all command flags required to build an image in one struct
 type BuildImageCommandFlags struct {
-	Type        string
-	CmdArgs     []string
-	CmdEnvs     []string
-	ImageName   string
-	Mounts      []string
-	TargetRoot  string
-	IPAddress   string
-	IPv6Address string
-	Netmask     string
-	Gateway     string
+	Type            string
+	CmdArgs         []string
+	DisableArgsCopy bool
+	CmdEnvs         []string
+	ImageName       string
+	Mounts          []string
+	TargetRoot      string
+	IPAddress       string
+	IPv6Address     string
+	Netmask         string
+	Gateway         string
 }
 
 // MergeToConfig overrides configuration passed by argument with command flags values
@@ -88,6 +89,8 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 		c.Args = flags.CmdArgs
 	}
 
+	c.DisableArgsCopy = flags.DisableArgsCopy
+
 	if c.Program != "" {
 		c.Args = append([]string{c.Program}, c.Args...)
 	}
@@ -146,6 +149,11 @@ func NewBuildImageCommandFlags(cmdFlags *pflag.FlagSet) (flags *BuildImageComman
 		exitWithError(err.Error())
 	}
 
+	flags.DisableArgsCopy, err = cmdFlags.GetBool("disable-args-copy")
+	if err != nil {
+		exitWithError(err.Error())
+	}
+
 	flags.Gateway, err = cmdFlags.GetString("gateway")
 	if err != nil {
 		exitWithError(err.Error())
@@ -177,6 +185,7 @@ func PersistBuildImageCommandFlags(cmdFlags *pflag.FlagSet) {
 	cmdFlags.StringP("imagename", "i", "", "image name")
 	cmdFlags.StringArray("mounts", nil, "mount <volume_id:mount_path>")
 	cmdFlags.StringArrayP("args", "a", nil, "command line arguments")
+	cmdFlags.BoolP("disable-args-copy", "", false, "disable copying of files passed as arguments")
 	cmdFlags.String("ip-address", "", "static ip address")
 	cmdFlags.String("ipv6-address", "", "static ipv6 address")
 	cmdFlags.String("gateway", "", "network gateway")

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -214,7 +214,7 @@ func BuildPackageManifest(packagepath string, c *types.Config) (*fs.Manifest, er
 		return nil, errors.Wrap(err, 1)
 	}
 
-	if len(c.Args) > 1 {
+	if !c.DisableArgsCopy && len(c.Args) > 1 {
 		if f, err := os.Stat(c.Args[1]); err == nil {
 			if f.IsDir() {
 				err = m.AddDirectory(c.Args[1], c.Args[1])

--- a/types/config.go
+++ b/types/config.go
@@ -5,6 +5,9 @@ type Config struct {
 	// Args defines an array of commands to execute when the image is launched.
 	Args []string
 
+	// Disable auto copy of files from host to container when present in args
+	DisableArgsCopy bool
+
 	// BaseVolumeSz is an optional parameter for defining the size of the base
 	// volume (defaults to the end of blocks written by TFS).
 	BaseVolumeSz string


### PR DESCRIPTION
This PR adds the `--disable-args-copy` option. I didn't want the first argument to be automatically copied as I was manually copying files and directory using a config file. This might be useful for other people.