### PR TITLE
add pkg login command and related functions

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -284,7 +284,7 @@ func cmdPkgLogin(cmd *cobra.Command, args []string) {
 	err = lepton.StoreCredentials(lepton.Credentials{
 		Username: resp.Username,
 		Email:    resp.Email,
-		ApiKey:   apikey,
+		APIKey:   apikey,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -283,7 +283,6 @@ func cmdPkgLogin(cmd *cobra.Command, args []string) {
 	}
 	err = lepton.StoreCredentials(lepton.Credentials{
 		Username: resp.Username,
-		Email:    resp.Email,
 		APIKey:   apikey,
 	})
 	if err != nil {

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -15,7 +15,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/log"
 )
@@ -111,7 +110,7 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 	if local {
 		packages, err = api.GetLocalPackageList()
 	} else {
-		packages, err = api.GetPackageList(lepton.NewConfig())
+		packages, err = api.GetPackageList(api.NewConfig())
 	}
 	if err != nil {
 		log.Errorf("failed getting packages: %s", err)
@@ -178,13 +177,13 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 }
 
 func cmdGetPackage(cmd *cobra.Command, args []string) {
-	downloadPackage(args[0], lepton.NewConfig())
+	downloadPackage(args[0], api.NewConfig())
 }
 
 func cmdPackageDescribe(cmd *cobra.Command, args []string) {
 	expackage := filepath.Join(packageDirectoryPath(), args[0])
 	if _, err := os.Stat(expackage); os.IsNotExist(err) {
-		expackage = downloadPackage(args[0], lepton.NewConfig())
+		expackage = downloadPackage(args[0], api.NewConfig())
 	}
 
 	description := path.Join(expackage, "README.md")
@@ -221,7 +220,7 @@ func cmdPackageContents(cmd *cobra.Command, args []string) {
 
 	expackage := filepath.Join(directoryPath, args[0])
 	if _, err := os.Stat(expackage); os.IsNotExist(err) {
-		expackage = downloadPackage(args[0], lepton.NewConfig())
+		expackage = downloadPackage(args[0], api.NewConfig())
 	}
 
 	filepath.Walk(expackage, func(hostpath string, info os.FileInfo, err error) error {
@@ -256,7 +255,7 @@ func cmdAddPackage(cmd *cobra.Command, args []string) {
 		name = token
 	}
 
-	extractFilePackage(args[0], name, lepton.NewConfig())
+	extractFilePackage(args[0], name, api.NewConfig())
 
 	fmt.Println(name)
 }
@@ -277,11 +276,11 @@ func cmdFromDockerPackage(cmd *cobra.Command, args []string) {
 
 func cmdPkgLogin(cmd *cobra.Command, args []string) {
 	apikey := args[0]
-	resp, err := lepton.ValidateAPIKey(apikey)
+	resp, err := api.ValidateAPIKey(apikey)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = lepton.StoreCredentials(lepton.Credentials{
+	err = api.StoreCredentials(api.Credentials{
 		Username: resp.Username,
 		APIKey:   apikey,
 	})
@@ -334,7 +333,7 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	pkgFlags := NewPkgCommandFlags(flags)
 	pkgFlags.Package = args[0]
 
-	c := lepton.NewConfig()
+	c := api.NewConfig()
 
 	mergeContainer := NewMergeConfigContainer(configFlags, globalFlags, nightlyFlags, nanosVersionFlags, buildImageFlags, runLocalInstanceFlags, pkgFlags)
 	err := mergeContainer.Merge(c)
@@ -347,9 +346,9 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 	if strings.Contains(executableName, packageFolder) {
 		executableName = filepath.Base(executableName)
 	} else {
-		executableName = filepath.Join(lepton.PackageSysRootFolderName, executableName)
+		executableName = filepath.Join(api.PackageSysRootFolderName, executableName)
 	}
-	lepton.ValidateELF(filepath.Join(pkgFlags.PackagePath(), executableName))
+	api.ValidateELF(filepath.Join(pkgFlags.PackagePath(), executableName))
 
 	if !runLocalInstanceFlags.SkipBuild {
 		if err = api.BuildImageFromPackage(pkgFlags.PackagePath(), *c); err != nil {

--- a/install.sh
+++ b/install.sh
@@ -169,8 +169,7 @@ ops_detect_supported_linux_distribution() {
 
 ops_brew_install_qemu() {
   if which brew >/dev/null; then
-    brew tap nanovms/homebrew-qemu
-    brew install nanovms/homebrew-qemu/qemu
+    brew install qemu
   else
     printf "Homebrew not found.Please install from https://brew.sh/"
   fi

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -26,13 +26,15 @@ const releaseBaseURL string = "https://storage.googleapis.com/nanos/release/"
 const nightlyReleaseBaseURL string = "https://storage.googleapis.com/nanos/release/nightly/"
 
 // PackageBaseURL gives URL for downloading of packages
-const PackageBaseURL string = "https://repo.ops.city/packages"
+const PackageBaseURL string = PkghubBaseURL + "/packages"
 
 // PackageManifestURL stores info about all packages
-const PackageManifestURL string = "https://repo.ops.city/manifest.json"
+const PackageManifestURL string = PkghubBaseURL + "/manifest.json"
 
 // PackageManifestFileName is manifest file path
 const PackageManifestFileName string = "manifest.json"
+
+const PkghubBaseURL string = "https://repo.ops.city"
 
 var (
 	// LocalVolumeDir is the default local volume directory

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -34,6 +34,7 @@ const PackageManifestURL string = PkghubBaseURL + "/manifest.json"
 // PackageManifestFileName is manifest file path
 const PackageManifestFileName string = "manifest.json"
 
+// PkghubBaseURL is the base url of packagehub
 const PkghubBaseURL string = "https://repo.ops.city"
 
 var (

--- a/lepton/login.go
+++ b/lepton/login.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 )
 
-// ApiKeyHeader is the header key where we set the api key for packagehub
-const ApiKeyHeader = "x-api-key"
+// APIKeyHeader is the header key where we set the api key for packagehub
+const APIKeyHeader = "x-api-key"
 
 // CredentialFileName is the name of the file which stores packagehub's credentials
 const CredentialFileName = "credentials"
@@ -40,7 +40,7 @@ func ValidateAPIKey(apikey string) (*ValidateSuccessResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(ApiKeyHeader, apikey)
+	req.Header.Add(APIKeyHeader, apikey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/lepton/login.go
+++ b/lepton/login.go
@@ -1,0 +1,91 @@
+package lepton
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+const API_KEY_HEADER = "x-api-key"
+const CredentialFileName = "credentials"
+
+var ErrCredentialsNotExist = errors.New("credentials not exist")
+
+type ValidateSuccessResponse struct {
+	Username string
+	Email    string
+	GithubID int
+}
+
+// Credentials is the information that will be stored in the ~/.ops/credentials
+type Credentials struct {
+	Username string
+	Email    string
+	ApiKey   string
+}
+
+// ValidateAPIKey uses the api key provided and sends it to validate endpoint of packagehub
+// if the response is a valid user then we return that or else error is returned.
+func ValidateAPIKey(apikey string) (*ValidateSuccessResponse, error) {
+	apikeyEndpoint := PkghubBaseURL + "/apikey/validate"
+	req, err := http.NewRequest("POST", apikeyEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(API_KEY_HEADER, apikey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == 200 {
+		successResp := ValidateSuccessResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&successResp)
+		if err != nil {
+			return nil, err
+		}
+		return &successResp, nil
+	} else if resp.StatusCode == 403 {
+		return nil, errors.New("incorrect api-key")
+	} else {
+		// at this point its mostly a internal server error
+		reason, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New(string(reason))
+	}
+
+}
+
+// StoreCredentials stores the credentials in the credential file. Overrides it if there is
+// an existing one.
+func StoreCredentials(creds Credentials) error {
+	opsHome := GetOpsHome()
+	credentialFilePath := filepath.Join(opsHome, CredentialFileName)
+	data, err := json.Marshal(creds)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(credentialFilePath, data, 0644)
+}
+
+func ReadCredsFromLocal() (*Credentials, error) {
+	opsHome := GetOpsHome()
+	credentialFilePath := filepath.Join(opsHome, CredentialFileName)
+	if _, err := os.Stat(credentialFilePath); os.IsNotExist(err) {
+		return nil, ErrCredentialsNotExist
+	}
+	data, err := ioutil.ReadFile(credentialFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := Credentials{}
+	if err = json.Unmarshal(data, &creds); err != nil {
+		return nil, err
+	}
+	return &creds, nil
+}

--- a/lepton/login.go
+++ b/lepton/login.go
@@ -21,14 +21,11 @@ var ErrCredentialsNotExist = errors.New("credentials not exist")
 // ValidateSuccessResponse is the structure of the success response from validate api key endpoint
 type ValidateSuccessResponse struct {
 	Username string
-	Email    string
-	GithubID int
 }
 
 // Credentials is the information that will be stored in the ~/.ops/credentials
 type Credentials struct {
 	Username string
-	Email    string
 	APIKey   string
 }
 

--- a/lepton/login.go
+++ b/lepton/login.go
@@ -9,11 +9,16 @@ import (
 	"path/filepath"
 )
 
-const API_KEY_HEADER = "x-api-key"
+// ApiKeyHeader is the header key where we set the api key for packagehub
+const ApiKeyHeader = "x-api-key"
+
+// CredentialFileName is the name of the file which stores packagehub's credentials
 const CredentialFileName = "credentials"
 
+// ErrCredentialsNotExist is the error we return if the credential file doesn't exist
 var ErrCredentialsNotExist = errors.New("credentials not exist")
 
+// ValidateSuccessResponse is the structure of the success response from validate api key endpoint
 type ValidateSuccessResponse struct {
 	Username string
 	Email    string
@@ -24,7 +29,7 @@ type ValidateSuccessResponse struct {
 type Credentials struct {
 	Username string
 	Email    string
-	ApiKey   string
+	APIKey   string
 }
 
 // ValidateAPIKey uses the api key provided and sends it to validate endpoint of packagehub
@@ -35,7 +40,7 @@ func ValidateAPIKey(apikey string) (*ValidateSuccessResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(API_KEY_HEADER, apikey)
+	req.Header.Add(ApiKeyHeader, apikey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -72,6 +77,9 @@ func StoreCredentials(creds Credentials) error {
 	return ioutil.WriteFile(credentialFilePath, data, 0644)
 }
 
+// ReadCredsFromLocal gets the credentials from the credential file in the ops home
+// returns an ErrCredentialsNotExist if the file doesn't exist. This means the user
+// hasn't authenticated yet.
 func ReadCredsFromLocal() (*Credentials, error) {
 	opsHome := GetOpsHome()
 	credentialFilePath := filepath.Join(opsHome, CredentialFileName)

--- a/lepton/login.go
+++ b/lepton/login.go
@@ -35,7 +35,7 @@ type Credentials struct {
 // ValidateAPIKey uses the api key provided and sends it to validate endpoint of packagehub
 // if the response is a valid user then we return that or else error is returned.
 func ValidateAPIKey(apikey string) (*ValidateSuccessResponse, error) {
-	apikeyEndpoint := PkghubBaseURL + "/apikey/validate"
+	apikeyEndpoint := PkghubBaseURL + "/apikeys/validate"
 	req, err := http.NewRequest("POST", apikeyEndpoint, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Adds the `ops pkg login <apikey>` command which validates the api key from packagehub and stores it in `~/.ops/credentials` to be used in other commands.

## Testing

- Login to packagehub
- Generate an API key using the api key section
- use that api key in ops using `ops pkg login <key>`
- if the api key is correct you will see a message `Login Successful as user <Username>`.
- if the api key is incorrect you will see `incorrect api-key` error