### PR TITLE
Image create: add IMAGE_NAME environment variable

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -307,6 +307,7 @@ func setManifestFromConfig(m *fs.Manifest, c *types.Config) error {
 	m.AddEnvironmentVariable("PWD", "/")
 	m.AddEnvironmentVariable("OPS_VERSION", Version)
 	m.AddEnvironmentVariable("NANOS_VERSION", c.NanosVersion)
+	m.AddEnvironmentVariable("IMAGE_NAME", c.CloudConfig.ImageName)
 	for k, v := range c.Env {
 		m.AddEnvironmentVariable(k, v)
 	}


### PR DESCRIPTION
This can be used by Nanos to identify the image where it is running (see e.g. https://github.com/nanovms/nanos/pull/1674).