### PR TITLE
fix help text for ops volume attach

### DIFF
--- a/cmd/cmd_volume.go
+++ b/cmd/cmd_volume.go
@@ -142,8 +142,8 @@ func volumeAttachCommand() *cobra.Command {
 }
 
 func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
-	instance_name := args[0]
-	volume_name := args[1]
+	instanceName := args[0]
+	volumeName := args[1]
 
 	c, err := getVolumeCommandDefaultConfig(cmd)
 	if err != nil {
@@ -155,7 +155,7 @@ func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = p.AttachVolume(ctx, instance_name, volume_name)
+	err = p.AttachVolume(ctx, instanceName, volumeName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cmd_volume.go
+++ b/cmd/cmd_volume.go
@@ -133,7 +133,7 @@ func volumeDeleteCommandHandler(cmd *cobra.Command, args []string) {
 
 func volumeAttachCommand() *cobra.Command {
 	cmdVolumeAttach := &cobra.Command{
-		Use:   "attach <image_name> <volume_name>",
+		Use:   "attach <instance_name> <volume_name>",
 		Short: "attach volume",
 		Run:   volumeAttachCommandHandler,
 		Args:  cobra.MinimumNArgs(2),
@@ -142,8 +142,8 @@ func volumeAttachCommand() *cobra.Command {
 }
 
 func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
-	image := args[0]
-	name := args[1]
+	instance_name := args[0]
+	volume_name := args[1]
 
 	c, err := getVolumeCommandDefaultConfig(cmd)
 	if err != nil {
@@ -155,7 +155,7 @@ func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = p.AttachVolume(ctx, image, name)
+	err = p.AttachVolume(ctx, instance_name, volume_name)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -61,11 +61,11 @@ type Storage interface {
 
 // VolumeService is an interface for volume related operations
 type VolumeService interface {
-	CreateVolume(ctx *Context, name, data, provider string) (NanosVolume, error)
+	CreateVolume(ctx *Context, volumeName, data, provider string) (NanosVolume, error)
 	GetAllVolumes(ctx *Context) (*[]NanosVolume, error)
-	DeleteVolume(ctx *Context, name string) error
-	AttachVolume(ctx *Context, image, name string) error
-	DetachVolume(ctx *Context, image, name string) error
+	DeleteVolume(ctx *Context, volumeName string) error
+	AttachVolume(ctx *Context, instanceName, volumeName string) error
+	DetachVolume(ctx *Context, instainceName, volumeName string) error
 }
 
 // DNSRecord is ops representation of a dns record


### PR DESCRIPTION
the current help for `ops volume attach` seems to be incorrect as it shows the first arg to be `image_name` but really expects `instance_name` so changing that.
Also changed the instance argument names to reflect this change.