### PR TITLE
Add KlibDir and filter out Terminated AWS instances

### DIFF
--- a/aws/aws_instance.go
+++ b/aws/aws_instance.go
@@ -507,6 +507,7 @@ func (p *AWS) findInstanceByName(name string) (*ec2.Instance, error) {
 	filter := []*ec2.Filter{
 		{Name: aws.String("tag:CreatedBy"), Values: aws.StringSlice([]string{"ops"})},
 		{Name: aws.String("tag:Name"), Values: aws.StringSlice([]string{name})},
+		{Name: aws.String("instance-state-name"), Values: aws.StringSlice([]string{"running", "pending", "shutting-down", "stopping", "stopped"})},
 	}
 
 	request := ec2.DescribeInstancesInput{

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -243,7 +243,11 @@ func setManifestFromConfig(m *fs.Manifest, c *types.Config) error {
 	addDNSConfig(m, c)
 	addHostName(m, c)
 	addPasswd(m, c)
-	m.SetKlibDir(getKlibsDir(c.NightlyBuild))
+	if c.KlibDir != "" {
+		m.SetKlibDir(c.KlibDir)
+	} else {
+		m.SetKlibDir(getKlibsDir(c.NightlyBuild))
+	}
 
 	m.AddKlibs(c.RunConfig.Klibs)
 

--- a/types/config.go
+++ b/types/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// Kernel
 	Kernel string
 
+	// Klibs host location
+	KlibDir string
+
 	// MapDirs specifies a map of local directories to add to into the image.
 	// These directory paths are then adjusted from local path specification
 	// to image path specification.


### PR DESCRIPTION
This PR has some miscellaneous changes. It adds a new Config option, KlibDir, to specify the location of Klibs when using
a custom kernel. It also filters out Terminated instances when looking up an instance on AWS so operations can be
applied to the correct (non-terminated) instance of the same name.