### PR TITLE
AWS: add support for associating elastic IP address to instance

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -127,6 +127,9 @@ type ProviderConfig struct {
 	// DomainName
 	DomainName string
 
+	// AWS Elastic IP address
+	ElasticIP string
+
 	// EnableIPv6 enables IPv6 when creating a vpc. It does not affect an existing VPC
 	EnableIPv6 bool
 


### PR DESCRIPTION
With this change, when creating an AWS instance it is possible to specify in the configuration file an elastic IP address to be
associated to the instance. Example:
```
"CloudConfig" :{
	"ElasticIP": "1.2.3.4"
}
```
The IP address must be allocated to the AWS account from which the instance is being created.