### PR TITLE
Kernel and boot files: fix usage of custom files

### DIFF
--- a/cmd/flags_nanos_version.go
+++ b/cmd/flags_nanos_version.go
@@ -30,6 +30,9 @@ func (flags *NanosVersionCommandFlags) MergeToConfig(config *types.Config) (err 
 			}
 		}
 
+		// override Boot and Kernel parameters in configuration file
+		config.Boot = ""
+		config.Kernel = ""
 		updateNanosToolsPaths(config, nanosVersion)
 		config.NanosVersion = nanosVersion
 	} else {

--- a/cmd/flags_nightly.go
+++ b/cmd/flags_nightly.go
@@ -60,17 +60,14 @@ func updateNanosToolsPaths(c *types.Config, version string) {
 		c.Boot = path.Join(api.GetOpsHome(), version, "boot.img")
 	}
 
-	// user provided flag takes presidence config params
-	newBootPath := path.Join(api.GetOpsHome(), version, "boot.img")
-	if c.Boot == "" || c.Boot != newBootPath {
+	if c.Boot == "" {
 		c.Boot = path.Join(api.GetOpsHome(), version, "boot.img")
 	}
 
 	c.UefiBoot = api.GetUefiBoot(version)
 
-	newKernelPath := path.Join(api.GetOpsHome(), version, "kernel.img")
-	if c.Kernel == "" || c.Kernel != newKernelPath {
-		c.Kernel = newKernelPath
+	if c.Kernel == "" {
+		c.Kernel = path.Join(api.GetOpsHome(), version, "kernel.img")
 	}
 
 	if _, err := os.Stat(c.Kernel); os.IsNotExist(err) {


### PR DESCRIPTION
Since commit 8f40b6a61985dee97c2006b747fbc5227819cf01, specifying a custom kernel or boot file in config.json no longer works, because these file paths are overwritten with the paths from the current Nanos release.
This commit fixes the above issue so that file paths specified in config.json are only overwritten if a Nanos version (or a nightly build) is specified by the user.