### PR TITLE
Volume attach: add support for specifying attachment point

### DIFF
--- a/azure/azure_volume.go
+++ b/azure/azure_volume.go
@@ -144,7 +144,7 @@ func (a *Azure) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume attaches a volume to an instance
-func (a *Azure) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (a *Azure) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	vmClient := a.getVMClient()
 
 	vm, err := vmClient.Get(context.TODO(), a.groupName, image, compute.InstanceView)

--- a/cmd/cmd_volume.go
+++ b/cmd/cmd_volume.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"log"
+	"strconv"
+	"strings"
 
 	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/types"
@@ -144,6 +146,17 @@ func volumeAttachCommand() *cobra.Command {
 func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
 	instanceName := args[0]
 	volumeName := args[1]
+	attachID := -1
+	attachIDPrefix := "%"
+	if strings.HasPrefix(volumeName, attachIDPrefix) {
+		attachStrings := strings.Split(strings.TrimPrefix(volumeName, attachIDPrefix), ":")
+		if len(attachStrings) == 2 {
+			if id, err := strconv.Atoi(attachStrings[0]); err == nil {
+				attachID = id
+				volumeName = attachStrings[1]
+			}
+		}
+	}
 
 	c, err := getVolumeCommandDefaultConfig(cmd)
 	if err != nil {
@@ -155,7 +168,7 @@ func volumeAttachCommandHandler(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = p.AttachVolume(ctx, instanceName, volumeName)
+	err = p.AttachVolume(ctx, instanceName, volumeName, attachID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nanovms/ops/types"
 
 	"github.com/nanovms/ops/lepton"
-	"github.com/nanovms/ops/onprem"
 	"github.com/spf13/pflag"
 )
 
@@ -79,7 +78,7 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 	}
 
 	if flags.Mounts != nil {
-		err = onprem.AddMounts(flags.Mounts, c)
+		err = lepton.AddMounts(flags.Mounts, c)
 		if err != nil {
 			return
 		}

--- a/cmd/flags_config.go
+++ b/cmd/flags_config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/log"
-	"github.com/nanovms/ops/onprem"
 	"github.com/nanovms/ops/types"
 	"github.com/spf13/pflag"
 )
@@ -70,11 +69,6 @@ func ConvertJSONToConfig(data []byte, c *types.Config) (err error) {
 			err = fmt.Errorf("%w ~ error near '%s' (offset %d) line: %v", err, problemPart, jsonErr.Offset, line)
 		}
 		return ErrInvalidFileConfig(err)
-	}
-
-	c.VolumesDir = lepton.LocalVolumeDir
-	if c.Mounts != nil {
-		err = onprem.AddMountsFromConfig(c)
 	}
 
 	if c.RunConfig.IPAddress != "" && !isIPAddressValid(c.RunConfig.IPAddress) {

--- a/cmd/run_local_instance.go
+++ b/cmd/run_local_instance.go
@@ -3,13 +3,22 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/network"
+	"github.com/nanovms/ops/onprem"
 	"github.com/nanovms/ops/qemu"
 	"github.com/nanovms/ops/types"
 )
 
 // RunLocalInstance runs a virtual machine in a hypervisor
 func RunLocalInstance(c *types.Config) (err error) {
+	if c.Mounts != nil {
+		c.VolumesDir = lepton.LocalVolumeDir
+		err = onprem.AddMountsFromConfig(c)
+		if err != nil {
+			return
+		}
+	}
 	hypervisor := qemu.HypervisorInstance()
 	if hypervisor == nil {
 		ErrNoHypervisor := "No hypervisor found on $PATH"

--- a/digitalocean/digital_ocean_volume.go
+++ b/digitalocean/digital_ocean_volume.go
@@ -19,7 +19,7 @@ func (do *DigitalOcean) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume is a stub to satisfy VolumeService interface
-func (do *DigitalOcean) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (do *DigitalOcean) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	return nil
 }
 

--- a/gcp/gcp_volume.go
+++ b/gcp/gcp_volume.go
@@ -152,7 +152,7 @@ func (g *GCloud) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume attaches Compute Engine Disk volume to existing instance
-func (g *GCloud) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (g *GCloud) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	config := ctx.Config()
 
 	disk := &compute.AttachedDisk{

--- a/hyperv/hyperv.go
+++ b/hyperv/hyperv.go
@@ -53,7 +53,7 @@ func (p *Provider) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume is a stub
-func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	return errors.New("Unsupported")
 }
 

--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -64,7 +64,7 @@ type VolumeService interface {
 	CreateVolume(ctx *Context, volumeName, data, provider string) (NanosVolume, error)
 	GetAllVolumes(ctx *Context) (*[]NanosVolume, error)
 	DeleteVolume(ctx *Context, volumeName string) error
-	AttachVolume(ctx *Context, instanceName, volumeName string) error
+	AttachVolume(ctx *Context, instanceName, volumeName string, attachID int) error
 	DetachVolume(ctx *Context, instanceName, volumeName string) error
 }
 

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -210,3 +210,25 @@ func GetSizeInGb(size string) (int, error) {
 	}
 	return int(sizeInGb), nil
 }
+
+// AddMounts adds Mounts and RunConfig.Mounts to image from flags
+func AddMounts(mounts []string, config *types.Config) error {
+	if config.Mounts == nil {
+		config.Mounts = make(map[string]string)
+	}
+	for _, mnt := range mounts {
+		lm := strings.Split(mnt, VolumeDelimiter)
+		if len(lm) != 2 {
+			return fmt.Errorf("mount config invalid: missing parts: %s", mnt)
+		}
+		if lm[1] == "" || lm[1][0] != '/' {
+			return fmt.Errorf("mount config invalid: %s", mnt)
+		}
+		_, ok := config.Mounts[lm[0]]
+		if ok {
+			return fmt.Errorf("mount path occupied: %s", lm[0])
+		}
+		config.Mounts[lm[0]] = lm[1]
+	}
+	return nil
+}

--- a/oci/oci_volume.go
+++ b/oci/oci_volume.go
@@ -107,7 +107,7 @@ func (p *Provider) DeleteVolume(ctx *lepton.Context, name string) (err error) {
 }
 
 // AttachVolume attaches a volume to an oci instance
-func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string) (err error) {
+func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string, attachID int) (err error) {
 	return errors.New("Unsupported")
 
 	_, err = p.computeClient.AttachVolume(context.TODO(), core.AttachVolumeRequest{

--- a/onprem/onprem_instance.go
+++ b/onprem/onprem_instance.go
@@ -32,6 +32,14 @@ func (p *OnPrem) CreateInstance(ctx *lepton.Context) error {
 		return fmt.Errorf("image \"%s\" not found", imageName)
 	}
 
+	if c.Mounts != nil {
+		c.VolumesDir = lepton.LocalVolumeDir
+		err := AddMountsFromConfig(c)
+		if err != nil {
+			return err
+		}
+	}
+
 	hypervisor := qemu.HypervisorInstance()
 	if hypervisor == nil {
 		fmt.Println("No hypervisor found on $PATH")

--- a/onprem/onprem_volume.go
+++ b/onprem/onprem_volume.go
@@ -144,45 +144,6 @@ func filterVolume(all []lepton.NanosVolume, query map[string]string) ([]lepton.N
 	return vols, nil
 }
 
-// AddMounts adds Mounts and RunConfig.Mounts to image from flags
-func AddMounts(mounts []string, config *types.Config) error {
-	if config.Mounts == nil {
-		config.Mounts = make(map[string]string)
-	}
-	query := make(map[string]string)
-
-	for _, mnt := range mounts {
-		lm := strings.Split(mnt, lepton.VolumeDelimiter)
-		if len(lm) != 2 {
-			return fmt.Errorf("mount config invalid: missing parts: %s", mnt)
-		}
-		if lm[1] == "" || lm[1][0] != '/' {
-			return fmt.Errorf("mount config invalid: %s", mnt)
-		}
-
-		query["id"] = lm[0]
-		query["label"] = lm[0]
-		vols, err := GetVolumes(config.VolumesDir, query)
-		if err != nil {
-			return err
-		}
-
-		if len(vols) == 0 {
-			return fmt.Errorf("volume with uuid/label %s not found", lm[0])
-		} else if len(vols) > 1 {
-			return fmt.Errorf("ambiguous volume uuid/label: %s: multiple volumes found", lm[0])
-		}
-		_, ok := config.Mounts[lm[0]]
-		if ok {
-			return fmt.Errorf("mount path occupied: %s", lm[0])
-		}
-		config.Mounts[lm[0]] = lm[1]
-		config.RunConfig.Mounts = append(config.RunConfig.Mounts, vols[0].Path)
-	}
-
-	return nil
-}
-
 // AddMountsFromConfig adds RunConfig.Mounts to image from existing Mounts
 // to simulate attach/detach volume locally
 func AddMountsFromConfig(config *types.Config) error {

--- a/onprem/onprem_volume.go
+++ b/onprem/onprem_volume.go
@@ -66,7 +66,7 @@ func (op *OnPrem) DeleteVolume(ctx *lepton.Context, name string) error {
 // on `ops image create --mount`, it simply creates a mount path
 // with the given volume label
 // label can refer to volume UUID or volume label
-func (op *OnPrem) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (op *OnPrem) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	log.Warn("not implemented")
 	fmt.Println("use <ops run> or <ops pkg load> with --mounts flag instead")
 	fmt.Println("alternatively, use <ops image create -t onprem> with --mounts flag")

--- a/onprem/onprem_volume_test.go
+++ b/onprem/onprem_volume_test.go
@@ -178,7 +178,7 @@ func TestOnPremVolume_AddMounts(t *testing.T) {
 			}
 
 			mounts = append(mounts, fmt.Sprintf("%s:%s", tt.mount, tt.mountAt))
-			err = onprem.AddMounts(mounts, config)
+			err = lepton.AddMounts(mounts, config)
 			if err != nil {
 				if !tt.err {
 					t.Errorf("AddMounts: %v", err)

--- a/openstack/openstack_volume.go
+++ b/openstack/openstack_volume.go
@@ -173,7 +173,7 @@ func (o *OpenStack) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume is a stub to satisfy VolumeService interface
-func (o *OpenStack) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (o *OpenStack) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	computeClient, err := o.getComputeClient()
 	if err != nil {
 		return err

--- a/proxmox/proxmox_volume.go
+++ b/proxmox/proxmox_volume.go
@@ -19,7 +19,7 @@ func (p *ProxMox) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume is a stub to satisfy VolumeService interface
-func (p *ProxMox) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (p *ProxMox) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	return nil
 }
 

--- a/upcloud/upcloud_volume.go
+++ b/upcloud/upcloud_volume.go
@@ -99,7 +99,7 @@ func (p *Provider) DeleteVolume(ctx *lepton.Context, name string) (err error) {
 }
 
 // AttachVolume attaches a storage to an upcloud server
-func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string) (err error) {
+func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string, attachID int) (err error) {
 	instance, err := p.GetInstanceByName(ctx, image)
 	if err != nil {
 		return

--- a/upcloud/upcloud_volume_test.go
+++ b/upcloud/upcloud_volume_test.go
@@ -65,7 +65,7 @@ func TestAttachVolume(t *testing.T) {
 		StartServer(&request.StartServerRequest{UUID: serverID}).
 		Return(&upcloud.ServerDetails{Server: upcloud.Server{UUID: serverID, Title: serverName}}, nil)
 
-	err := p.AttachVolume(testutils.NewMockContext(), serverName, volumeName)
+	err := p.AttachVolume(testutils.NewMockContext(), serverName, volumeName, 1)
 
 	assert.Nil(t, err)
 }

--- a/vbox/vbox_volume.go
+++ b/vbox/vbox_volume.go
@@ -35,7 +35,7 @@ func (p *Provider) DeleteVolume(ctx *lepton.Context, name string) (err error) {
 }
 
 // AttachVolume attaches a storage to an upcloud server
-func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string) (err error) {
+func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string, attachID int) (err error) {
 	err = errors.New("Unsupported")
 
 	return

--- a/vsphere/vsphere_volume.go
+++ b/vsphere/vsphere_volume.go
@@ -170,7 +170,7 @@ func (v *Vsphere) DeleteVolume(ctx *lepton.Context, name string) (err error) {
 }
 
 // AttachVolume attaches a volume to an instance
-func (v *Vsphere) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (v *Vsphere) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	f := find.NewFinder(v.client, true)
 	ds, err := f.DatastoreOrDefault(context.TODO(), v.datastore)
 	if err != nil {

--- a/vultr/vultr_volume.go
+++ b/vultr/vultr_volume.go
@@ -19,7 +19,7 @@ func (v *Vultr) DeleteVolume(ctx *lepton.Context, name string) error {
 }
 
 // AttachVolume is a stub to satisfy VolumeService interface
-func (v *Vultr) AttachVolume(ctx *lepton.Context, image, name string) error {
+func (v *Vultr) AttachVolume(ctx *lepton.Context, image, name string, attachID int) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR adds to the `volume attach` command the option to specify a volume identifier argument with format `%<attach_id>:<volume_name>` (where <attach_id> is an integer number indicating an attachment point) instead of `<volume_name>`.
Example: `ops volume attach myInstance %1:myVolume` attaches the volume identified by `myVolume` to an instance using 1 as attachment point.
The allowed values for the attachment point vary based on the deployment target; currently, this feature is only implemented for the AWS cloud provider, where the valid range for attachment points is [1-25].
If the attachment point is not specified in a volume attach command, a suitable attachment point is chosen automatically.

The attachment point can be used (alternatively to the volume name) to identify a volume in a mount directive. For example, the `--mounts %1:/mnt` command line option (or alternatively the `"Mounts": {"%1": "/mnt"}` JSON attribute in the configuration file) can be used to mount the volume with attachment point 1 in the /mnt directory.