### PR TITLE
GCP/Azure volume attach: implement handling of attachment point

### DIFF
--- a/azure/azure_volume.go
+++ b/azure/azure_volume.go
@@ -172,6 +172,13 @@ func (a *Azure) AttachVolume(ctx *lepton.Context, image, name string, attachID i
 			},
 		},
 	}
+	if attachID > 0 {
+		if attachID < 64 {
+			(*vm.StorageProfile.DataDisks)[0].Lun = to.Int32Ptr(int32(attachID))
+		} else {
+			return fmt.Errorf("invalid attachment point %d; allowed values: 0-63", attachID)
+		}
+	}
 
 	future, err := vmClient.CreateOrUpdate(context.TODO(), a.groupName, image, vm)
 	if err != nil {

--- a/gcp/gcp_volume.go
+++ b/gcp/gcp_volume.go
@@ -157,8 +157,14 @@ func (g *GCloud) AttachVolume(ctx *lepton.Context, image, name string, attachID 
 
 	disk := &compute.AttachedDisk{
 		AutoDelete: false,
-		DeviceName: name,
 		Source:     fmt.Sprintf("zones/%s/disks/%s", config.CloudConfig.Zone, name),
+	}
+	if attachID >= 0 {
+		if attachID > 0 {
+			disk.DeviceName = fmt.Sprintf("persistent-disk-%d", attachID)
+		} else {
+			return fmt.Errorf("attachment point 0 is reserved for the boot disk")
+		}
 	}
 	op, err := g.Service.Instances.AttachDisk(config.CloudConfig.ProjectID, config.CloudConfig.Zone, image, disk).Context(context.TODO()).Do()
 	if err != nil {


### PR DESCRIPTION
In GCP, the attachment point is reflected in the device name associated to a disk (using the same format "persistent-disk-n" as used when a device name is assigned a default value).
In Azure, the attachment point is reflected in the disk Logical Unit Number.