### PR TITLE
Fix CI errors

### DIFF
--- a/cmd/flags_build_image_test.go
+++ b/cmd/flags_build_image_test.go
@@ -66,8 +66,9 @@ func TestBuildImageFlagsMergeToConfig(t *testing.T) {
 			Program:    "MyTestApp",
 		}
 		expected := &types.Config{
-			Boot:   opsPath + "/boot.img",
-			Kernel: opsPath + "/kernel.img",
+			Boot:     opsPath + "/boot.img",
+			UefiBoot: opsPath + "/bootx64.efi",
+			Kernel:   opsPath + "/kernel.img",
 			Mounts: map[string]string{
 				volumeName: "/files",
 			},
@@ -114,6 +115,7 @@ func TestBuildImageFlagsMergeToConfig(t *testing.T) {
 
 		expected := &types.Config{
 			Boot:                opsPath + "/boot.img",
+			UefiBoot:            opsPath + "/bootx64.efi",
 			Kernel:              opsPath + "/kernel.img",
 			Mounts:              map[string]string{},
 			CloudConfig:         types.ProviderConfig{},

--- a/onprem/onprem_volume_test.go
+++ b/onprem/onprem_volume_test.go
@@ -175,6 +175,8 @@ func TestOnPremVolume_AddMounts(t *testing.T) {
 			err = os.Symlink(src, dst)
 			if err != nil {
 				log.Error(err)
+			} else {
+				defer os.Remove(dst)
 			}
 
 			mounts = append(mounts, fmt.Sprintf("%s:%s", tt.mount, tt.mountAt))


### PR DESCRIPTION
Fix TestBuildImageFlagsMergeToConfig by adding the UefiBoot path to expected results and fix miscellaneous symlink
error in TestBuildImageFlagsMergeToConfig by removing created symlink between tests.

For flags merging, the UefiBoot path is set in updateNanosToolsPaths() even if Uefi is not set.