### PR TITLE
Add feature to upload public and private packages to organization namespaces

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -352,7 +352,7 @@ func cmdPkgLogin(cmd *cobra.Command, args []string) {
 }
 
 func cmdPkgPush(cmd *cobra.Command, args []string) {
-	packageFolder := args[0]
+	pkgIdentifier := args[0]
 	creds, err := api.ReadCredsFromLocal()
 	if err != nil {
 		if err == api.ErrCredentialsNotExist {
@@ -362,13 +362,17 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 	}
-	name, version := api.GetPkgnameAndVersion(packageFolder)
+
+	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
 	pkgList, err := api.GetLocalPackageList()
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	_, packageFolder := api.ExtractNS(pkgIdentifier)
 	localPackages := filepath.Join(api.GetOpsHome(), "local_packages")
 	var foundPkg api.Package
+
 	for _, pkg := range pkgList {
 		if pkg.Name == name && pkg.Version == version {
 			foundPkg = pkg
@@ -387,7 +391,7 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(archiveName)
 
-	req, err := lepton.BuildRequestForArchiveUpload(name, foundPkg, archiveName)
+	req, err := lepton.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -109,6 +109,8 @@ func PackageCommands() *cobra.Command {
 	cmdFromDockerPackage.MarkPersistentFlagRequired("file")
 	cmdFromDockerPackage.PersistentFlags().StringP("name", "n", "", "name of the package")
 
+	cmdPkgPush.PersistentFlags().BoolP("private", "p", false, "set the package as private")
+
 	cmdPkg.AddCommand(cmdPkgList)
 	cmdPkg.AddCommand(cmdPkgSearch)
 	cmdPkg.AddCommand(cmdGetPackage)
@@ -352,6 +354,8 @@ func cmdPkgLogin(cmd *cobra.Command, args []string) {
 }
 
 func cmdPkgPush(cmd *cobra.Command, args []string) {
+	flags := cmd.Flags()
+
 	pkgIdentifier := args[0]
 	creds, err := api.ReadCredsFromLocal()
 	if err != nil {
@@ -363,6 +367,7 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	private, _ := flags.GetBool("private")
 	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
 	pkgList, err := api.GetLocalPackageList()
 	if err != nil {
@@ -391,7 +396,7 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(archiveName)
 
-	req, err := lepton.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName)
+	req, err := lepton.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName, private)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -437,6 +437,8 @@ func GetNSPkgnameAndVersion(pkgIdentifier string) (string, string, string) {
 	return namespace, result["packageName"], result["version"]
 }
 
+// ExtractNS extracts namespace from the package identifier of format <namespace>/<packageWithVersion>
+// and returns the namespace and package with version
 func ExtractNS(identifier string) (string, string) {
 	namespace := ""
 	pkgIdfs := strings.Split(identifier, "/")

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -264,7 +264,7 @@ func GetLocalPackageList() ([]Package, error) {
 
 		// ignore packages compressed
 		if !strings.Contains(pkgName, "tar.gz") {
-			name, _ := GetPkgnameAndVersion(pkgName)
+			_, name, _ := GetNSPkgnameAndVersion(pkgName)
 			data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/package.manifest", localPackagesDir, pkgName))
 			if err != nil {
 				return nil, err
@@ -420,18 +420,30 @@ func BuildImageFromPackage(packagepath string, c types.Config) error {
 	return nil
 }
 
-// GetPkgnameAndVersion gets the name and version from the pkg identifier
-func GetPkgnameAndVersion(pkgIdentifier string) (string, string) {
-	match := packageRegex.FindStringSubmatch(pkgIdentifier)
+// GetNSPkgnameAndVersion gets the name and version from the pkg identifier
+func GetNSPkgnameAndVersion(pkgIdentifier string) (string, string, string) {
+	namespace, pkgIdf := ExtractNS(pkgIdentifier)
+	match := packageRegex.FindStringSubmatch(pkgIdf)
 	result := make(map[string]string)
 	// mostly then there is no version in the name and hence we can return all of it
 	if len(match) == 0 {
-		return pkgIdentifier, "latest"
+		return namespace, pkgIdf, "latest"
 	}
 	for i, name := range packageRegex.SubexpNames() {
 		if i != 0 && name != "" {
 			result[name] = match[i]
 		}
 	}
-	return result["packageName"], result["version"]
+	return namespace, result["packageName"], result["version"]
+}
+
+func ExtractNS(identifier string) (string, string) {
+	namespace := ""
+	pkgIdfs := strings.Split(identifier, "/")
+	pkgIdf := pkgIdfs[0]
+	if len(pkgIdfs) > 1 {
+		namespace = pkgIdfs[0]
+		pkgIdf = pkgIdfs[1]
+	}
+	return namespace, pkgIdf
 }

--- a/lepton/push.go
+++ b/lepton/push.go
@@ -14,13 +14,14 @@ import (
 )
 
 // BuildRequestForArchiveUpload builds the request to upload a package with the provided metadata
-func BuildRequestForArchiveUpload(name string, pkg Package, archiveLocation string) (*http.Request, error) {
+func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLocation string) (*http.Request, error) {
 	params := map[string]string{
 		"name":        name,
 		"description": pkg.Description,
 		"language":    pkg.Language,
 		"runtime":     pkg.Runtime,
 		"version":     pkg.Version,
+		"namespace":   namespace,
 	}
 	return newfileUploadRequest(PkghubBaseURL+"/packages/create", params, "package", archiveLocation)
 

--- a/lepton/push.go
+++ b/lepton/push.go
@@ -14,7 +14,11 @@ import (
 )
 
 // BuildRequestForArchiveUpload builds the request to upload a package with the provided metadata
-func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLocation string) (*http.Request, error) {
+func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLocation string, private bool) (*http.Request, error) {
+	privateStr := "off"
+	if private {
+		privateStr = "on"
+	}
 	params := map[string]string{
 		"name":        name,
 		"description": pkg.Description,
@@ -22,6 +26,7 @@ func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLo
 		"runtime":     pkg.Runtime,
 		"version":     pkg.Version,
 		"namespace":   namespace,
+		"private":     privateStr,
 	}
 	return newfileUploadRequest(PkghubBaseURL+"/packages/create", params, "package", archiveLocation)
 


### PR DESCRIPTION
This change adds the support for uploading to org namespace. The way it works is that now you can provide an optional namespace prefix to your local folder
```
ops pkg push test/golang-1.8.1
```
Here ops will use the `test` as namespace and `golang-1.8.1` would be folder name it will search in `local_package`.