### PR TITLE
fuzzy match version when pushing package and some fixes

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -366,13 +366,14 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 	}
-
 	private, _ := flags.GetBool("private")
 	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
 	pkgList, err := api.GetLocalPackageList()
 	if err != nil {
 		log.Fatal(err)
 	}
+	fmt.Println(ns, name, version)
+
 	_, packageFolder := api.ExtractNS(pkgIdentifier)
 	localPackages := filepath.Join(api.GetOpsHome(), "local_packages")
 	var foundPkg api.Package

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -376,7 +376,7 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 	_, packageFolder := api.ExtractNS(pkgIdentifier)
 	localPackages := filepath.Join(api.GetOpsHome(), "local_packages")
 	var foundPkg api.Package
-	fmt.Println(ns, name, version)
+
 	for _, pkg := range pkgList {
 		// trip the "v" if provided in the version
 		if pkg.Name == name && strings.TrimPrefix(pkg.Version, "v") == strings.TrimPrefix(version, "v") {

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -372,7 +372,6 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(ns, name, version)
 
 	_, packageFolder := api.ExtractNS(pkgIdentifier)
 	localPackages := filepath.Join(api.GetOpsHome(), "local_packages")

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -373,13 +373,13 @@ func cmdPkgPush(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	_, packageFolder := api.ExtractNS(pkgIdentifier)
 	localPackages := filepath.Join(api.GetOpsHome(), "local_packages")
 	var foundPkg api.Package
-
+	fmt.Println(ns, name, version)
 	for _, pkg := range pkgList {
-		if pkg.Name == name && pkg.Version == version {
+		// trip the "v" if provided in the version
+		if pkg.Name == name && strings.TrimPrefix(pkg.Version, "v") == strings.TrimPrefix(version, "v") {
 			foundPkg = pkg
 			break
 		}

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -265,21 +265,26 @@ func GetLocalPackageList() ([]Package, error) {
 		// ignore packages compressed
 		if !strings.Contains(pkgName, "tar.gz") {
 			_, name, _ := GetNSPkgnameAndVersion(pkgName)
-			data, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/package.manifest", localPackagesDir, pkgName))
-			if err != nil {
-				return nil, err
+			manifestLoc := fmt.Sprintf("%s/%s/package.manifest", localPackagesDir, pkgName)
+			if _, err := os.Stat(manifestLoc); err == nil {
+
+				data, err := ioutil.ReadFile(manifestLoc)
+				if err != nil {
+					return nil, err
+				}
+
+				var pkg Package
+				err = json.Unmarshal(data, &pkg)
+				if err != nil {
+					fmt.Printf("having trouble parsing the manifest of package: %s - can you verify the package.manifest is correct via jsonlint.com?\n", pkgName)
+					os.Exit(1)
+					return nil, err
+				}
+				pkg.Namespace = username
+				pkg.Name = name
+				packages = append(packages, pkg)
 			}
 
-			var pkg Package
-			err = json.Unmarshal(data, &pkg)
-			if err != nil {
-				fmt.Printf("having trouble parsing the manifest of package: %s - can you verify the package.manifest is correct via jsonlint.com?\n", pkgName)
-				os.Exit(1)
-				return nil, err
-			}
-			pkg.Namespace = username
-			pkg.Name = name
-			packages = append(packages, pkg)
 		}
 	}
 


### PR DESCRIPTION
Fixes the version mismatch when `v` is set as prefix.
`node_v16.5.0` folder but manifest says `16.5.0`. So now we fuzzy match the version.

Also only read local manifest if it exists