### PR TITLE
Handle read-only flag appended to mount paths

### DIFF
--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -86,7 +86,8 @@ func (m *Manifest) SetKlibDir(dir string) {
 // AddMount adds mount
 func (m *Manifest) AddMount(label, path string) {
 	dir := strings.TrimPrefix(path, "/")
-	mkDirPath(m.rootDir(), dir)
+	dirparts := strings.Split(dir, ":")
+	mkDirPath(m.rootDir(), dirparts[0])
 	if m.root["mounts"] == nil {
 		m.root["mounts"] = make(map[string]interface{})
 	}

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -218,7 +218,7 @@ func AddMounts(mounts []string, config *types.Config) error {
 	}
 	for _, mnt := range mounts {
 		lm := strings.Split(mnt, VolumeDelimiter)
-		if len(lm) != 2 {
+		if len(lm) < 2 {
 			return fmt.Errorf("mount config invalid: missing parts: %s", mnt)
 		}
 		if lm[1] == "" || lm[1][0] != '/' {
@@ -228,7 +228,7 @@ func AddMounts(mounts []string, config *types.Config) error {
 		if ok {
 			return fmt.Errorf("mount path occupied: %s", lm[0])
 		}
-		config.Mounts[lm[0]] = lm[1]
+		config.Mounts[lm[0]] = strings.Join(lm[1:], ":")
 	}
 	return nil
 }


### PR DESCRIPTION
The mount path for a volume may now optionally have ":ro" appended to it
indicating to mount read-only. AddMount must be changed to handle trimming
this from the path in order to create a correct mount directory, and AddMounts
changed to save the flag back to the mount path after removing it.