### PR TITLE
GCP images: automatically enable UEFI on ARM images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             make test | tee ${TEST_RESULTS}/go-test.out
   build-mac:
     macos:
-        xcode: "12.2.0"
+        xcode: "14.0.0"
     environment:
       TEST_RESULTS: /tmp/test-results
     steps:

--- a/gcp/gcp_image.go
+++ b/gcp/gcp_image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nanovms/ops/lepton"
@@ -18,9 +19,16 @@ import (
 // GCPStorageURL is GCP storage path
 const GCPStorageURL string = "https://storage.googleapis.com/%v/%v"
 
+func amendConfig(c *types.Config) {
+	if strings.HasPrefix(c.CloudConfig.Flavor, "t2a") {
+		c.Uefi = true
+	}
+}
+
 // BuildImage to be upload on GCP
 func (p *GCloud) BuildImage(ctx *lepton.Context) (string, error) {
 	c := ctx.Config()
+	amendConfig(c)
 	err := lepton.BuildImage(*c)
 	if err != nil {
 		return "", err
@@ -62,6 +70,7 @@ func (p *GCloud) CustomizeImage(ctx *lepton.Context) (string, error) {
 // BuildImageWithPackage to upload on GCP
 func (p *GCloud) BuildImageWithPackage(ctx *lepton.Context, pkgpath string) (string, error) {
 	c := ctx.Config()
+	amendConfig(c)
 	err := lepton.BuildImageFromPackage(pkgpath, *c)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
GCP t2a instances boot with UEFI and thus require an UEFI bootloader in their images. This commit enables automatically UEFI when an image is being created for a GPC t2a instance.

The XCode version used in the CircleCI Mac build is being updated to the latest supported version 14.0.0, since the previously used version 12.2.0 is no longer supported by CircleCI.