### PR TITLE
Adding ProxMox NODE_NAME configurable environment variable

### DIFF
--- a/proxmox/proxmox.go
+++ b/proxmox/proxmox.go
@@ -10,10 +10,10 @@ import (
 
 // ProxMox provides access to the ProxMox API.
 type ProxMox struct {
-	Storage *Objects
-	tokenID string
-	secret  string
-	apiURL  string
+	Storage  *Objects
+	tokenID  string
+	secret   string
+	apiURL   string
 	nodeNAME string
 }
 

--- a/proxmox/proxmox.go
+++ b/proxmox/proxmox.go
@@ -14,6 +14,7 @@ type ProxMox struct {
 	tokenID string
 	secret  string
 	apiURL  string
+	nodeNAME string
 }
 
 // Initialize provider
@@ -31,6 +32,11 @@ func (p *ProxMox) Initialize(config *types.ProviderConfig) error {
 	p.apiURL = os.Getenv("API_URL")
 	if p.apiURL == "" {
 		return fmt.Errorf("API_URL is not set")
+	}
+
+	p.nodeNAME = os.Getenv("NODE_NAME")
+	if p.nodeNAME == "" {
+		p.nodeNAME = "pve"
 	}
 
 	return nil

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -86,7 +86,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	w.Close()
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/pve/storage/local/upload", &b)
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/local/upload", &b)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -139,7 +139,7 @@ type ImageInfo struct {
 // ListImages lists images on ProxMox
 func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 
-	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/pve/storage/local/content", nil)
+	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/local/content", nil)
 	if err != nil {
 		fmt.Println(err)
 		return err

--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -63,7 +63,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	data.Set("name", imageName)
 	data.Set("net0", "model=virtio,bridge=vmbr0")
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/pve/qemu", bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu", bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -102,7 +102,7 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string, imageName stri
 	data.Set("virtio0", "file=local:iso/"+imageName)
 	data.Set("boot", "order=virtio0")
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/pve/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -160,7 +160,7 @@ type InstanceInfo struct {
 // ListInstances lists instances on Proxmox.
 func (p *ProxMox) ListInstances(ctx *lepton.Context) error {
 
-	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/pve/qemu", nil)
+	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu", nil)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -215,7 +215,7 @@ func (p *ProxMox) ListInstances(ctx *lepton.Context) error {
 // DeleteInstance deletes instance from Proxmox.
 func (p *ProxMox) DeleteInstance(ctx *lepton.Context, instanceID string) error {
 
-	req, err := http.NewRequest("DELETE", p.apiURL+"/api2/json/nodes/pve/qemu/"+instanceID, nil)
+	req, err := http.NewRequest("DELETE", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID, nil)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -247,7 +247,7 @@ func (p *ProxMox) DeleteInstance(ctx *lepton.Context, instanceID string) error {
 // StartInstance starts an instance in Proxmox
 func (p *ProxMox) StartInstance(ctx *lepton.Context, instanceID string) error {
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/pve/qemu/"+instanceID+"/status/start", nil)
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID+"/status/start", nil)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -277,7 +277,7 @@ func (p *ProxMox) StartInstance(ctx *lepton.Context, instanceID string) error {
 // StopInstance halts instance from Proxmox.
 func (p *ProxMox) StopInstance(ctx *lepton.Context, instanceID string) error {
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/pve/qemu/"+instanceID+"/status/stop", nil)
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID+"/status/stop", nil)
 	if err != nil {
 		fmt.Println(err)
 		return err


### PR DESCRIPTION
Added a new environment variable NODE_NAME for use with ProxMox.
If NODE_NAME is not set, then NODE_NAME = "pve" as auto fallback with use "pve" value for backward compatibility.