### PR TITLE
Add checks for data results from ProxMox API

### DIFF
--- a/proxmox/proxmox.go
+++ b/proxmox/proxmox.go
@@ -19,6 +19,9 @@ type ProxMox struct {
 
 // Initialize provider
 func (p *ProxMox) Initialize(config *types.ProviderConfig) error {
+
+	var err error
+
 	p.tokenID = os.Getenv("TOKEN_ID")
 	if p.tokenID == "" {
 		return fmt.Errorf("TOKEN_ID is not set")
@@ -37,6 +40,11 @@ func (p *ProxMox) Initialize(config *types.ProviderConfig) error {
 	p.nodeNAME = os.Getenv("NODE_NAME")
 	if p.nodeNAME == "" {
 		p.nodeNAME = "pve"
+	}
+
+	err = p.CheckInit()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/proxmox/proxmox_checks.go
+++ b/proxmox/proxmox_checks.go
@@ -1,0 +1,140 @@
+package proxmox
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type pData struct {
+	Data string `json:"data"`
+}
+
+type pDataArr struct {
+	Data []string `json:"data"`
+}
+
+// CheckInit return custom error on {"data": null} or {"data": []} result come from ProxMox API /api2/json/pools
+func (p *ProxMox) CheckInit() error {
+
+	var err error
+
+	var b bytes.Buffer
+
+	ecs := errors.New("check token permissions, environment variables correctness, having at least one pool in proxmox")
+
+	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/pools", &b)
+	if err != nil {
+		return err
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = checkData(body)
+	if err != nil {
+		return ecs
+	}
+
+	debug := false
+	if debug {
+		fmt.Println(string(body))
+	}
+
+	return nil
+
+}
+
+// CheckResult return custom error when {"data": null} or {"data": []} result come from ProxMox API (Not used now)
+func (p *ProxMox) CheckResult(body []byte) error {
+
+	var err error
+
+	ecs := errors.New("check token permissions, environment variables correctness")
+
+	err = checkData(body)
+	if err != nil {
+		return ecs
+	}
+
+	return nil
+
+}
+
+// CheckResultType return custom errors based on type of check, when {"data": null} or {"data": []} result come from ProxMox API
+func (p *ProxMox) CheckResultType(body []byte, rtype string) error {
+
+	var err error
+
+	edef := "check token permissions, environment variables correctness"
+	ecs := errors.New(edef)
+
+	switch rtype {
+	case "createimage":
+		ecs = errors.New("can not create disk image in 'local' storage, " + edef)
+	case "listimages":
+		ecs = errors.New("no have any disk images in 'local' storage or " + edef)
+	case "createinstance":
+		ecs = errors.New("can not create machine instance with disk image from 'local' storage, " + edef)
+	case "getnextid":
+		ecs = errors.New("can not get next id, " + edef)
+	case "movdisk":
+		ecs = errors.New("can not move iso to raw disk on 'local-lvm' storage, " + edef)
+	case "addvirtiodisk":
+		ecs = errors.New("can not add virtio disk from 'local' storage, " + edef)
+	case "bootorderset":
+		ecs = errors.New("can not set boot order, " + edef)
+	}
+
+	err = checkData(body)
+	if err != nil {
+		return ecs
+	}
+
+	return nil
+
+}
+
+// checkData return custom error on {"data": null} or {"data": []} result come from JSON with 'data' string/array field
+func checkData(body []byte) error {
+
+	var err error
+
+	var pd pData
+	var apd pDataArr
+
+	edk := errors.New("empty data key")
+
+	err = json.Unmarshal(body, &pd)
+	if err != nil {
+		err = json.Unmarshal(body, &apd)
+		if err == nil && apd.Data == nil {
+			return edk
+		}
+	}
+
+	if err == nil && pd.Data == "" {
+		return edk
+	}
+
+	return nil
+
+}

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -123,6 +123,11 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 		return err
 	}
 
+	err = p.CheckResultType(body, "createimage")
+	if err != nil {
+		return err
+	}
+
 	debug := false
 	if debug {
 		fmt.Println(string(body))
@@ -171,6 +176,11 @@ func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println(err)
+		return err
+	}
+
+	err = p.CheckResultType(body, "listimages")
+	if err != nil {
 		return err
 	}
 

--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -43,6 +43,11 @@ func (p *ProxMox) getNextID() string {
 		fmt.Println(err)
 	}
 
+	err = p.CheckResultType(body, "getnextid")
+	if err != nil {
+		return ""
+	}
+
 	ir := &NextIDResponse{}
 	json.Unmarshal([]byte(body), ir)
 
@@ -80,9 +85,14 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println(err)
+		return err
+	}
+
+	err = p.CheckResultType(body, "createinstance")
+	if err != nil {
 		return err
 	}
 
@@ -125,6 +135,11 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string, imageName string) er
 		return err
 	}
 
+	err = p.CheckResultType(body, "movdisk")
+	if err != nil {
+		return err
+	}
+
 	debug := false
 	if debug {
 		fmt.Println(string(body))
@@ -163,6 +178,11 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string, imageName stri
 		return err
 	}
 
+	err = p.CheckResultType(body, "addvirtiodisk")
+	if err != nil {
+		return err
+	}
+
 	// set boot order, needs to come after attaching disk
 	data.Set("boot", "order=virtio0")
 
@@ -182,6 +202,11 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string, imageName stri
 	body, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Println(err)
+		return err
+	}
+
+	err = p.CheckResultType(body, "bootorderset")
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Added functions with checks {"data": null} or {"data":[]} results from ProxMox API.
This is need for checking permissions in proxmox, correctness environment variables etc.
It is required in order to stop the ops giving the result as if everything is fine, but in fact nothing works with proxmox.
Currently in error messages uses 'local' and 'local-lvm' hard-coded words, later when we have customizable name of storages, this words be replaced by variables.
