### PR TITLE
Added error checking coming from ProxMox API

### DIFF
--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -96,8 +96,12 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 
-	p.addVirtioDisk(ctx, nextid, imageName)
-	p.movDisk(ctx, nextid, imageName)
+	err = p.addVirtioDisk(ctx, nextid, imageName)
+	if err != nil {
+		return err
+	}
+
+	err = p.movDisk(ctx, nextid, imageName)
 
 	return err
 }


### PR DESCRIPTION
Added capture errors from ProxMox API.
Unfortunately, ProxMox does not always return an error, for example, in the case of a disk move, if there is no storage local-lvm, then the error is not returned. ProxMox doesn't have the best API.