### PR TITLE
Added some configurable options for ProxMox API via CloudConfig

### DIFF
--- a/cmd/cmd_instance.go
+++ b/cmd/cmd_instance.go
@@ -96,6 +96,8 @@ func instanceCreateCommandHandler(cmd *cobra.Command, args []string) {
 	if err != nil {
 		exitWithError(err.Error())
 	}
+
+	fmt.Printf("%s instance '%s' created...\n", c.CloudConfig.Platform, c.RunConfig.InstanceName)
 }
 
 func instanceListCommand() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/docker/distribution v2.8.0+incompatible
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
 	github.com/go-errors/errors v1.0.1

--- a/lepton/helpers.go
+++ b/lepton/helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -16,6 +18,18 @@ const (
 	Month    = 30 * Day
 	Year     = 12 * Month
 	LongTime = 37 * Year
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
 )
 
 // Time2Human formats a time into a relative string.
@@ -45,6 +59,8 @@ type RelTimeMagnitude struct {
 	DivBy  time.Duration
 }
 
+type unitMap map[byte]int64
+
 var defaultMagnitudes = []RelTimeMagnitude{
 	{time.Second, "now", time.Second},
 	{2 * time.Second, "1 second %s", 1},
@@ -64,6 +80,13 @@ var defaultMagnitudes = []RelTimeMagnitude{
 	{LongTime, "%d years %s", Year},
 	{math.MaxInt64, "a long while %s", 1},
 }
+
+var (
+	decimalMap   = unitMap{'k': KB, 'm': MB, 'g': GB, 't': TB, 'p': PB}
+	binaryMap    = unitMap{'k': KiB, 'm': MiB, 'g': GiB, 't': TiB, 'p': PiB}
+	decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+	binaryAbbrs  = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+)
 
 // RelTime formats a time into a relative string.
 //
@@ -131,4 +154,78 @@ func Bytes2Human(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB",
 		float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	// TODO: rewrite to use strings.Cut if there's a space
+	// once Go < 1.18 is deprecated.
+	sep := strings.LastIndexAny(sizeStr, "01234567890. ")
+	if sep == -1 {
+		// There should be at least a digit.
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+	var num, sfx string
+	if sizeStr[sep] != ' ' {
+		num = sizeStr[:sep+1]
+		sfx = sizeStr[sep+1:]
+	} else {
+		// Omit the space separator.
+		num = sizeStr[:sep]
+		sfx = sizeStr[sep+1:]
+	}
+
+	size, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return -1, err
+	}
+	// Backward compatibility: reject negative sizes.
+	if size < 0 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	if len(sfx) == 0 {
+		return int64(size), nil
+	}
+
+	// Process the suffix.
+
+	if len(sfx) > 3 { // Too long.
+		goto badSuffix
+	}
+	sfx = strings.ToLower(sfx)
+	// Trivial case: b suffix.
+	if sfx[0] == 'b' {
+		if len(sfx) > 1 { // no extra characters allowed after b.
+			goto badSuffix
+		}
+		return int64(size), nil
+	}
+	// A suffix from the map.
+	if mul, ok := uMap[sfx[0]]; ok {
+		size *= float64(mul)
+	} else {
+		goto badSuffix
+	}
+
+	// The suffix may have extra "b" or "ib" (e.g. KiB or MB).
+	switch {
+	case len(sfx) == 2 && sfx[1] != 'b':
+		goto badSuffix
+	case len(sfx) == 3 && sfx[1:] != "ib":
+		goto badSuffix
+	}
+
+	return int64(size), nil
+
+badSuffix:
+	return -1, fmt.Errorf("invalid suffix: '%s'", sfx)
 }

--- a/proxmox/proxmox_checks.go
+++ b/proxmox/proxmox_checks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 type pData struct {
@@ -22,10 +23,21 @@ type sData struct {
 	Active  int    `json:"active"`
 	Enabled int    `json:"enabled"`
 	Storage string `json:"storage"`
+	Content string `json:"content"`
 }
 
 type sDataArr struct {
 	Data []sData `json:"data"`
+}
+
+type bData struct {
+	Active int    `json:"active"`
+	Type   string `json:"type"`
+	Iface  string `json:"iface"`
+}
+
+type bDataArr struct {
+	Data []bData `json:"data"`
 }
 
 // CheckInit return custom error on {"data": null} or {"data": []} result come from ProxMox API /api2/json/pools
@@ -75,7 +87,7 @@ func (p *ProxMox) CheckInit() error {
 }
 
 // CheckStorage return error when not found configured storage or any storages via ProxMox API
-func (p *ProxMox) CheckStorage(storage string) error {
+func (p *ProxMox) CheckStorage(storage string, stype string) error {
 
 	var err error
 
@@ -87,6 +99,8 @@ func (p *ProxMox) CheckStorage(storage string) error {
 	enb := errors.New("storage is disabled: " + storage)
 	ect := errors.New("storage is not active: " + storage)
 	ecs := errors.New("not found storage: " + storage)
+	eim := errors.New("storage is not configured for containing disk images: " + storage)
+	eis := errors.New("storage is not configured for containing iso images: " + storage)
 
 	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage", &b)
 	if err != nil {
@@ -137,6 +151,94 @@ func (p *ProxMox) CheckStorage(storage string) error {
 				return enb
 			}
 
+			if stype == "images" {
+
+				if !strings.Contains(v.Content, stype) {
+					return eim
+				}
+
+			} else if stype == "iso" {
+
+				if !strings.Contains(v.Content, stype) {
+					return eis
+				}
+
+			} else {
+				return errors.New("unknown type of storage")
+			}
+
+			return nil
+
+		}
+	}
+
+	return ecs
+
+}
+
+// CheckBridge return error when not found configured bridge any network interfaces via ProxMox API
+func (p *ProxMox) CheckBridge(bridge string) error {
+
+	var err error
+
+	var brs bDataArr
+
+	var b bytes.Buffer
+
+	edk := errors.New("no any bridges is configured")
+	ebr := errors.New("is not a bridge: " + bridge)
+	ect := errors.New("bridge is not active: " + bridge)
+	ecs := errors.New("not found bridge: " + bridge)
+
+	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/network", &b)
+	if err != nil {
+		return err
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, &brs)
+	if err != nil {
+		return err
+	}
+
+	if err == nil && brs.Data == nil {
+		return edk
+	}
+
+	debug := false
+	if debug {
+		fmt.Println(string(body))
+	}
+
+	for _, v := range brs.Data {
+
+		if v.Iface == bridge {
+
+			if v.Active != 1 {
+				return ect
+			}
+
+			if v.Type != "bridge" {
+				return ebr
+			}
+
 			return nil
 
 		}
@@ -168,7 +270,7 @@ func (p *ProxMox) CheckResult(body []byte) error {
 }
 
 // CheckResultType return error or custom error based on type of check, when {"data": null} or {"data": []} result come from ProxMox API
-func (p *ProxMox) CheckResultType(body []byte, rtype string) error {
+func (p *ProxMox) CheckResultType(body []byte, rtype string, rname string) error {
 
 	var err error
 
@@ -177,17 +279,17 @@ func (p *ProxMox) CheckResultType(body []byte, rtype string) error {
 
 	switch rtype {
 	case "createimage":
-		ecs = errors.New("can not create disk image in 'local' storage, " + edef)
+		ecs = errors.New("can not create disk image in " + rname + " storage, " + edef)
 	case "listimages":
-		ecs = errors.New("no disk images found in 'local' storage or " + edef)
+		ecs = errors.New("no disk images found in " + rname + " storage or " + edef)
 	case "createinstance":
-		ecs = errors.New("can not create machine instance with disk image from 'local' storage, " + edef)
+		ecs = errors.New("can not create machine instance with disk image from " + rname + " image/storage, " + edef)
 	case "getnextid":
 		ecs = errors.New("can not get next id, " + edef)
 	case "movdisk":
-		ecs = errors.New("can not move iso to raw disk on 'local-lvm' storage, " + edef)
+		ecs = errors.New("can not move iso to raw disk on " + rname + " storage, " + edef)
 	case "addvirtiodisk":
-		ecs = errors.New("can not add virtio disk from 'local' storage, " + edef)
+		ecs = errors.New("can not add virtio disk from " + rname + " storage, " + edef)
 	case "bootorderset":
 		ecs = errors.New("can not set boot order, " + edef)
 	}

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -66,7 +66,8 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 	c := ctx.Config()
 
 	imageName := c.CloudConfig.ImageName
-	isoStorageName := c.CloudConfig.IsoStorageName
+
+	isoStorageName := c.ProxmoxConfig.IsoStorageName
 
 	if isoStorageName == "" {
 		isoStorageName = "local"
@@ -172,7 +173,7 @@ func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 
 	c := ctx.Config()
 
-	isoStorageName := c.CloudConfig.StorageName
+	isoStorageName := c.ProxmoxConfig.StorageName
 
 	if isoStorageName == "" {
 		isoStorageName = "local"

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -65,7 +65,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	c := ctx.Config()
 
-	imageName := c.CloudConfig.ImageName
+	imageName := c.ProxmoxConfig.ImageName
 
 	isoStorageName := c.ProxmoxConfig.IsoStorageName
 

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -66,8 +66,13 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 	c := ctx.Config()
 
 	imageName := c.CloudConfig.ImageName
+	isoStorageName := c.CloudConfig.IsoStorageName
 
-	err = p.CheckStorage("local")
+	if isoStorageName == "" {
+		isoStorageName = "local"
+	}
+
+	err = p.CheckStorage(isoStorageName, "iso")
 	if err != nil {
 		return err
 	}
@@ -105,7 +110,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	w.Close()
 
-	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/local/upload", &b)
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/"+isoStorageName+"/upload", &b)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -131,7 +136,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 		return err
 	}
 
-	err = p.CheckResultType(body, "createimage")
+	err = p.CheckResultType(body, "createimage", isoStorageName)
 	if err != nil {
 		return err
 	}
@@ -163,7 +168,22 @@ type ImageInfo struct {
 // ListImages lists images on ProxMox
 func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 
-	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/local/content", nil)
+	var err error
+
+	c := ctx.Config()
+
+	isoStorageName := c.CloudConfig.StorageName
+
+	if isoStorageName == "" {
+		isoStorageName = "local"
+	}
+
+	err = p.CheckStorage(isoStorageName, "iso")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/"+isoStorageName+"/content", nil)
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -187,7 +207,7 @@ func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 		return err
 	}
 
-	err = p.CheckResultType(body, "listimages")
+	err = p.CheckResultType(body, "listimages", isoStorageName)
 	if err != nil {
 		return err
 	}

--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -65,13 +65,14 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 
 	instanceName := config.RunConfig.InstanceName
 
-	archType := config.CloudConfig.Arch
-	machineType := config.CloudConfig.Machine
-	socketsNum := config.CloudConfig.Sockets
-	coresNum := config.CloudConfig.Cores
-	numaStr := strconv.FormatBool(config.CloudConfig.Numa)
-	memoryHmn := config.CloudConfig.Memory
-	imageName := config.CloudConfig.ImageName
+	imageName := config.ProxmoxConfig.ImageName
+
+	archType := config.ProxmoxConfig.Arch
+	machineType := config.ProxmoxConfig.Machine
+	socketsNum := config.ProxmoxConfig.Sockets
+	coresNum := config.ProxmoxConfig.Cores
+	numaStr := strconv.FormatBool(config.ProxmoxConfig.Numa)
+	memoryHmn := config.ProxmoxConfig.Memory
 
 	storageName := config.ProxmoxConfig.StorageName
 	isoStorageName := config.ProxmoxConfig.IsoStorageName
@@ -80,7 +81,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	onbootStr := strconv.FormatBool(config.ProxmoxConfig.Onboot)
 	protectionStr := strconv.FormatBool(config.ProxmoxConfig.Protection)
 
-	// Check CloudConfig options
+	// Check ProxMox configuration options
 
 	if archType == "" {
 		archType = "x86_64"

--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/docker/go-units"
 	"github.com/nanovms/ops/lepton"
 	"github.com/olekukonko/tablewriter"
 )
@@ -73,12 +72,13 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	numaStr := strconv.FormatBool(config.CloudConfig.Numa)
 	memoryHmn := config.CloudConfig.Memory
 	imageName := config.CloudConfig.ImageName
-	storageName := config.CloudConfig.StorageName
-	isoStorageName := config.CloudConfig.IsoStorageName
-	bridgeName := config.CloudConfig.BridgeName
-	bridgeName0 := config.CloudConfig.BridgeName0
-	onbootStr := strconv.FormatBool(config.CloudConfig.Onboot)
-	protectionStr := strconv.FormatBool(config.CloudConfig.Protection)
+
+	storageName := config.ProxmoxConfig.StorageName
+	isoStorageName := config.ProxmoxConfig.IsoStorageName
+	bridgeName := config.ProxmoxConfig.BridgeName
+	bridgeName0 := config.ProxmoxConfig.BridgeName0
+	onbootStr := strconv.FormatBool(config.ProxmoxConfig.Onboot)
+	protectionStr := strconv.FormatBool(config.ProxmoxConfig.Protection)
 
 	// Check CloudConfig options
 
@@ -108,7 +108,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		memoryHmn = "512M"
 	}
 
-	memoryInt, err := units.RAMInBytes(memoryHmn)
+	memoryInt, err := lepton.RAMInBytes(memoryHmn)
 	if err != nil {
 		return err
 	}

--- a/types/config.go
+++ b/types/config.go
@@ -121,17 +121,12 @@ type Config struct {
 
 // ProviderConfig give provider details
 type ProviderConfig struct {
-	// Arch specifies the type of CPU architecture (Used only for ProxMox yet)
-	Arch string `cloud:"arch"`
 
 	// BucketName specifies the bucket to store the ops built image artifacts.
 	BucketName string `cloud:"bucketname"`
 
 	// BucketNamespace is required on uploading files to cloud providers as oci
 	BucketNamespace string
-
-	// Cores of CPU for instance (Used only for ProxMox yet)
-	Cores uint `cloud:"cores"`
 
 	// DomainName
 	DomainName string
@@ -155,15 +150,6 @@ type ProviderConfig struct {
 	// you can use to pass role information to an EC2 instance when the instance starts.
 	InstanceProfile string
 
-	// Machine specifies the type of machine (pc or q35) (Used only for ProxMox yet)
-	Machine string `cloud:"machine"`
-
-	// Memory for instance (Used only for ProxMox yet)
-	Memory string `cloud:"memory"`
-
-	// Numa for instance (Used only for ProxMox yet)
-	Numa bool `cloud:"numa"`
-
 	// Platform defines the cloud provider to use with the ops CLI, currently
 	// supporting aws, azure, and gcp.
 	Platform string `cloud:"platform"`
@@ -174,9 +160,6 @@ type ProviderConfig struct {
 
 	// SecurityGroup
 	SecurityGroup string
-
-	// Sockets of CPUs for instance (Used only for ProxMox yet)
-	Sockets uint `cloud:"sockets"`
 
 	// Subnet
 	Subnet string
@@ -197,6 +180,22 @@ type ProviderConfig struct {
 
 // ProxmoxConfig give provider details
 type ProxmoxConfig struct {
+
+	// Arch specifies the type of CPU architecture
+	Arch string `cloud:"arch"`
+
+	// Cores of CPU
+	Cores uint `cloud:"cores"`
+
+	// Machine specifies the type of machine
+	Machine string `cloud:"machine"`
+
+	// Memory
+	Memory string `cloud:"memory"`
+
+	// Numa
+	Numa bool `cloud:"numa"`
+
 	// BridgeName specifies the name of first bridge interface
 	BridgeName string `cloud:"bridgename"`
 
@@ -206,6 +205,9 @@ type ProxmoxConfig struct {
 	// BridgeName1 (secondary interface) specifies the name of first bridge interface (Not used yet)
 	BridgeName1 string `cloud:"bridgename1"`
 
+	// ImageName
+	ImageName string `cloud:"imagename"`
+
 	// IsoStorageName is used for upload intermediate iso images via ProxMox API
 	IsoStorageName string `cloud:"isostoragename"`
 
@@ -214,6 +216,9 @@ type ProxmoxConfig struct {
 
 	// Protection is used to define vm/image protection for instance (Used only for ProxMox yet)
 	Protection bool `cloud:"protection"`
+
+	// Sockets of CPUs
+	Sockets uint `cloud:"sockets"`
 
 	// StorageName is used for create bootable raw image for instance via ProxMox API from iso image
 	StorageName string `cloud:"storagename"`

--- a/types/config.go
+++ b/types/config.go
@@ -80,6 +80,9 @@ type Config struct {
 	// attach/detach.
 	ProgramPath string
 
+	// ProxmoxConfig configures various attributes about the ProxMox provider.
+	ProxmoxConfig ProxmoxConfig
+
 	// RebootOnExit defines whether the image should automatically reboot
 	// if an error/failure occurs.
 	RebootOnExit bool
@@ -121,12 +124,6 @@ type ProviderConfig struct {
 	// Arch specifies the type of CPU architecture (Used only for ProxMox yet)
 	Arch string `cloud:"arch"`
 
-	// BridgeName specifies the name of first bridge interface (Used only for ProxMox yet)
-	BridgeName string `cloud:"bridgename"`
-
-	// BridgeName0 (alias for BridgName) specifies the name of first bridge interface (Used only for ProxMox yet)
-	BridgeName0 string `cloud:"bridgename0"`
-
 	// BucketName specifies the bucket to store the ops built image artifacts.
 	BucketName string `cloud:"bucketname"`
 
@@ -158,9 +155,6 @@ type ProviderConfig struct {
 	// you can use to pass role information to an EC2 instance when the instance starts.
 	InstanceProfile string
 
-	// IsoStorageName is used for upload intermediate iso images via ProxMox API
-	IsoStorageName string `cloud:"isostoragename"`
-
 	// Machine specifies the type of machine (pc or q35) (Used only for ProxMox yet)
 	Machine string `cloud:"machine"`
 
@@ -170,9 +164,6 @@ type ProviderConfig struct {
 	// Numa for instance (Used only for ProxMox yet)
 	Numa bool `cloud:"numa"`
 
-	// Onboot is used to define automatic startup option for instance (Used only for ProxMox yet)
-	Onboot bool `cloud:"onboot"`
-
 	// Platform defines the cloud provider to use with the ops CLI, currently
 	// supporting aws, azure, and gcp.
 	Platform string `cloud:"platform"`
@@ -181,14 +172,8 @@ type ProviderConfig struct {
 	// to gcp.
 	ProjectID string `cloud:"projectid"`
 
-	// Protection is used to define vm/image protection for instance (Used only for ProxMox yet)
-	Protection bool `cloud:"protection"`
-
 	// SecurityGroup
 	SecurityGroup string
-
-	// StorageName is used for create bootable raw image for instance via ProxMox API from iso image
-	StorageName string `cloud:"storagename"`
 
 	// Sockets of CPUs for instance (Used only for ProxMox yet)
 	Sockets uint `cloud:"sockets"`
@@ -208,6 +193,30 @@ type ProviderConfig struct {
 	// azure: https://azure.microsoft.com/en-us/global-infrastructure/geographies/#overview
 	// gcp: https://cloud.google.com/compute/docs/regions-zones#available
 	Zone string `cloud:"zone"`
+}
+
+// ProxmoxConfig give provider details
+type ProxmoxConfig struct {
+	// BridgeName specifies the name of first bridge interface
+	BridgeName string `cloud:"bridgename"`
+
+	// BridgeName0 (alias for BridgeName) specifies the name of first bridge interface
+	BridgeName0 string `cloud:"bridgename0"`
+
+	// BridgeName1 (secondary interface) specifies the name of first bridge interface (Not used yet)
+	BridgeName1 string `cloud:"bridgename1"`
+
+	// IsoStorageName is used for upload intermediate iso images via ProxMox API
+	IsoStorageName string `cloud:"isostoragename"`
+
+	// Onboot is used to define automatic startup option for instance (Used only for ProxMox yet)
+	Onboot bool `cloud:"onboot"`
+
+	// Protection is used to define vm/image protection for instance (Used only for ProxMox yet)
+	Protection bool `cloud:"protection"`
+
+	// StorageName is used for create bootable raw image for instance via ProxMox API from iso image
+	StorageName string `cloud:"storagename"`
 }
 
 // Tag is used as property on creating instances

--- a/types/config.go
+++ b/types/config.go
@@ -118,11 +118,23 @@ type Config struct {
 
 // ProviderConfig give provider details
 type ProviderConfig struct {
+	// Arch specifies the type of CPU architecture (Used only for ProxMox yet)
+	Arch string `cloud:"arch"`
+
+	// BridgeName specifies the name of first bridge interface (Used only for ProxMox yet)
+	BridgeName string `cloud:"bridgename"`
+
+	// BridgeName0 (alias for BridgName) specifies the name of first bridge interface (Used only for ProxMox yet)
+	BridgeName0 string `cloud:"bridgename0"`
+
 	// BucketName specifies the bucket to store the ops built image artifacts.
 	BucketName string `cloud:"bucketname"`
 
 	// BucketNamespace is required on uploading files to cloud providers as oci
 	BucketNamespace string
+
+	// Cores of CPU for instance (Used only for ProxMox yet)
+	Cores uint `cloud:"cores"`
 
 	// DomainName
 	DomainName string
@@ -146,6 +158,21 @@ type ProviderConfig struct {
 	// you can use to pass role information to an EC2 instance when the instance starts.
 	InstanceProfile string
 
+	// IsoStorageName is used for upload intermediate iso images via ProxMox API
+	IsoStorageName string `cloud:"isostoragename"`
+
+	// Machine specifies the type of machine (pc or q35) (Used only for ProxMox yet)
+	Machine string `cloud:"machine"`
+
+	// Memory for instance (Used only for ProxMox yet)
+	Memory string `cloud:"memory"`
+
+	// Numa for instance (Used only for ProxMox yet)
+	Numa bool `cloud:"numa"`
+
+	// Onboot is used to define automatic startup option for instance (Used only for ProxMox yet)
+	Onboot bool `cloud:"onboot"`
+
 	// Platform defines the cloud provider to use with the ops CLI, currently
 	// supporting aws, azure, and gcp.
 	Platform string `cloud:"platform"`
@@ -154,8 +181,17 @@ type ProviderConfig struct {
 	// to gcp.
 	ProjectID string `cloud:"projectid"`
 
+	// Protection is used to define vm/image protection for instance (Used only for ProxMox yet)
+	Protection bool `cloud:"protection"`
+
 	// SecurityGroup
 	SecurityGroup string
+
+	// StorageName is used for create bootable raw image for instance via ProxMox API from iso image
+	StorageName string `cloud:"storagename"`
+
+	// Sockets of CPUs for instance (Used only for ProxMox yet)
+	Sockets uint `cloud:"sockets"`
 
 	// Subnet
 	Subnet string


### PR DESCRIPTION
[1356](https://github.com/nanovms/ops/issues/1356#issuecomment-1236103004) - Had some questions

1. Added full support of configurable options (CloudConfig) with backward compatibility:

Arch (Not work correctly through ProxMox API, but may be need later for other Clouds) (default: "" ; autodetect by ProxMox)
Machine (Not used if empty) (default: "" ; autodetect by ProxMox)
Sockets (default: "1")
Cores (default: "1")
Numa (default: "0")
Memory (default: "512M")
BridgeName (BridgeName0) (default: "vmbr0")
BridgeName1 (default: "") (Not used yet)
IsoStorageName (default: "local")
StorageName (default: "local-lvm")
Onboot (default: "0")
Protection (default: "0")

2. Added support for timestamps in instance names (if not used -i argument from command line).
3. Also fixed and extended some checks.
4. Added import dep of "github.com/docker/go-units" in proxmox/proxmox_instance.go for converting human-readable M,G memory settings to bytes for ProxMox

Short example of configuration file:
```
{
    "Dirs": ["static"],
    "NameServers": ["172.21.1.1"],
    "CloudConfig": {
        "BridgeName": "vmbr0",
        "ImageName": "mytest",
        "IsoStorageName": "local",
        "StorageName": "local-lvm"
    },
    "RunConfig": {
        "Accel": true,
        "InstanceName": "mytest",
        "ImageName": "mytest",
        "IPAddress": "172.21.1.75",
        "NetMask": "255.255.255.0",
        "Gateway": "172.21.1.1",
        "Verbose": true,
        "ShowErrors": true,
        "ShowWarnings": true
    }
}
```
Full example of configuration file:
```
{
    "Dirs": ["static"],
    "NameServers": ["172.21.1.1"],
    "CloudConfig": {
        "Arch": "x86_64",
        "Machine": "q35",
        "Sockets": 2,
        "Cores": 4,
        "Numa": true,
        "Memory": "4096M",
        "BridgeName0": "vmbr0",
        "ImageName": "mytest",
        "IsoStorageName": "local",
        "StorageName": "local-lvm",
        "Protection": false,
        "Onboot": true
    },
    "RunConfig": {
        "Accel": true,
        "InstanceName": "mytest",
        "ImageName": "mytest",
        "IPAddress": "172.21.1.75",
        "NetMask": "255.255.255.0",
        "Gateway": "172.21.1.1",
        "Verbose": true,
        "ShowErrors": true,
        "ShowWarnings": true
    }
}
```

Now with fully customizable base options, you can already normally use ops with ProxMox. It may be necessary to add some more options to the command line arguments, but this is after agreement with the Author of ops utility.