### PR TITLE
adding in support for multiple nics in proxmox

### DIFF
--- a/proxmox/proxmox_instance.go
+++ b/proxmox/proxmox_instance.go
@@ -65,7 +65,16 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	data := url.Values{}
 	data.Set("vmid", nextid)
 	data.Set("name", imageName)
-	data.Set("net0", "model=virtio,bridge=vmbr0")
+
+	nics := config.RunConfig.Nics
+	for i := 0; i < len(nics); i++ {
+		is := strconv.Itoa(i)
+		brName := nics[i].BridgeName
+		if brName == "" {
+			brName = "br" + is
+		}
+		data.Set("net"+is, "model=virtio,bridge="+brName)
+	}
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu", bytes.NewBufferString(data.Encode()))
 	if err != nil {

--- a/types/config.go
+++ b/types/config.go
@@ -239,6 +239,11 @@ type RunConfig struct {
 	// NetMask
 	NetMask string
 
+	// Nics is a list of pre-configured network cards
+	// Meant to eventually deprecate the existing single-nic configuration
+	// Currently only supported for Proxmox
+	Nics []Nic
+
 	// Background runs unikernel in background
 	// use onprem instances commands to manage the unikernel
 	Background bool
@@ -269,6 +274,25 @@ type RunConfig struct {
 
 	// VolumeSizeInGb is an optional parameter only available for OpenStack.
 	VolumeSizeInGb int
+}
+
+// Nic describes a nic
+// Currently only supported for Proxmox
+type Nic struct {
+	// IPAddress
+	IPAddress string
+
+	// IPv6Address
+	IPv6Address string
+
+	// NetMask
+	NetMask string
+
+	// Gateway
+	Gateway string
+
+	// BridgeName
+	BridgeName string
 }
 
 // RuntimeConfig constructs runtime config


### PR DESCRIPTION
this is a simple pr to enable multiple nics talking to different/same bridges like so (dhcp only for now):

```
{
  "RunConfig": {
    "Nics": [
      {
        "BridgeName": "vmbr0"
      },
      {
        "BridgeName": "vmbr0"
      }
    ]
  }
}
```

for now this only support proxmox, i'd imagine we'll end up deprecating the older RunConfig networking settings as we add this to more providers