### PR TITLE
Refactor ProxMox module, cosmetic fixes, better string logic

### DIFF
--- a/lepton/helpers.go
+++ b/lepton/helpers.go
@@ -3,6 +3,7 @@ package lepton
 import (
 	"fmt"
 	"math"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -141,7 +142,7 @@ func CustomRelTime(a, b time.Time, albl, blbl string, magnitudes []RelTimeMagnit
 	return fmt.Sprintf(mag.Format, args...)
 }
 
-// Bytes2Human parses bytes to other byte units as MegaByte and Gigabyte
+// Bytes2Human parses bytes to other byte units as MegaByte and Gigabyte.
 func Bytes2Human(b int64) string {
 	const unit = 1000
 	if b < unit {
@@ -164,7 +165,14 @@ func RAMInBytes(size string) (int64, error) {
 	return parseSize(size, binaryMap)
 }
 
-// Parses the human-readable size string into the amount it represents.
+// CCidr converts network mask to CIDR size.
+func CCidr(netmask string) int {
+	ip := net.ParseIP(netmask)
+	sz, _ := net.IPMask(ip.To4()).Size()
+	return sz
+}
+
+// parseSize parses the human-readable size string into the amount it represents.
 func parseSize(sizeStr string, uMap unitMap) (int64, error) {
 	// TODO: rewrite to use strings.Cut if there's a space
 	// once Go < 1.18 is deprecated.

--- a/proxmox/proxmox.go
+++ b/proxmox/proxmox.go
@@ -23,7 +23,7 @@ type ProxMox struct {
 	arch string `cloud:"arch"`
 
 	// cores of CPU
-	cores int `cloud:"cores"`
+	cores string `cloud:"cores"`
 
 	// machine specifies the type of machine
 	machine string `cloud:"machine"`
@@ -32,22 +32,28 @@ type ProxMox struct {
 	memory string `cloud:"memory"`
 
 	// numa
-	numa bool `cloud:"numa"`
+	numa string `cloud:"numa"`
+
+	// instanceName
+	instanceName string `cloud:"instancename"`
 
 	// imageName
 	imageName string `cloud:"imagename"`
+
+	// bridgePrefix - prefix for network bridge interfaces on bare metal host (like br/vmbr/bridge)
+	bridgePrefix string `cloud:"bridgeprefix"`
 
 	// isoStorageName is used for upload intermediate iso images via ProxMox API
 	isoStorageName string `cloud:"isostoragename"`
 
 	// onboot is used to define automatic startup option for instance
-	onboot bool `cloud:"onboot"`
+	onboot string `cloud:"onboot"`
 
 	// protection is used to define vm/image protection for instance
-	protection bool `cloud:"protection"`
+	protection string `cloud:"protection"`
 
 	// sockets of CPUs
-	sockets int `cloud:"sockets"`
+	sockets string `cloud:"sockets"`
 
 	// storageName is used for create bootable raw image for instance via ProxMox API from iso image
 	storageName string `cloud:"storagename"`

--- a/proxmox/proxmox_image.go
+++ b/proxmox/proxmox_image.go
@@ -63,11 +63,13 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	var err error
 
-	p.imageName = ctx.Config().CloudConfig.ImageName
-	p.isoStorageName = ctx.Config().TargetConfig["isoStorageName"]
+	config := ctx.Config()
 
-	if p.isoStorageName == "" {
-		p.isoStorageName = "local"
+	p.imageName = config.CloudConfig.ImageName
+
+	p.isoStorageName = "local"
+	if config.TargetConfig["isoStorageName"] != "" {
+		p.isoStorageName = config.TargetConfig["isoStorageName"]
 	}
 
 	err = p.CheckStorage(p.isoStorageName, "iso")
@@ -168,10 +170,11 @@ func (p *ProxMox) ListImages(ctx *lepton.Context) error {
 
 	var err error
 
-	p.isoStorageName = ctx.Config().TargetConfig["isoStorageName"]
+	config := ctx.Config()
 
-	if p.isoStorageName == "" {
-		p.isoStorageName = "local"
+	p.isoStorageName = "local"
+	if config.TargetConfig["isoStorageName"] != "" {
+		p.isoStorageName = config.TargetConfig["isoStorageName"]
 	}
 
 	err = p.CheckStorage(p.isoStorageName, "iso")


### PR DESCRIPTION
This pull request contains cosmetic changes, minor refactoring, capitalization of option names in the configuration file.
Removed unnecessary type conversions and checks. Everything is converted to a string type.

Example of config.json for Proxmox module (Current state):

```
{
    "Dirs": ["etc"],
    "NameServers": ["172.21.1.51"],
    "ManifestPassthrough": {
        "syslog": {
            "server": "172.21.1.51"
        }
    },
    "TargetConfig": {
        "Arch": "x86_64",
        "Machine": "q35",
        "Sockets": "1",
        "Cores": "8",
        "Numa": "0",
        "Memory": "4096M",
        "BridgePrefix": "vmbr",
        "IsoStorageName": "local",
        "StorageName": "local-lvm",
        "Protection": "0",
        "Onboot": "1"
    },
    "RunConfig": {
        "Klibs": ["syslog"],
        "Accel": true,
        "InstanceName": "usd",
        "ImageName": "usd",
        "Nics": [
            {"IPAddress": "0.0.0.0", "NetMask": "255.255.255.0"},
            {"IPAddress": "172.21.1.73", "NetMask": "255.255.255.0", "Gateway": "172.21.1.51"}
        ],
        "Verbose": true,
        "ShowErrors": true,
        "ShowWarnings": true
    }
}
```