### PR TITLE
[:tada:] add env var interpolation to config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,30 @@ ops run -p <port> <app>
 ops run -p <port> -c <file> <app>
 ```
 
+# Use golang string interoplation in config files
+To enable set `ops_render_config` to `true`. Both `${ENV_VAR}` and `$ENV_VAR` are supported.
+
+## Example Command
+```sh
+ops_render_config=true ops run -p <port> -c <file> <app>
+# or
+export ops_render_config=true
+ops run -p <port> -c <file> <app>
+```
+
+## Example config
+```JSON
+{
+  "Args":[
+    "--user",
+    "${USER}",
+    "--password",
+    "$PASSWORD"
+  ],
+  "Dirs":["myapp/static"]
+}
+```
+
 # Example config file
 
 OPS config files are plain JSON, below is an example.
@@ -176,7 +200,7 @@ Only advanced/power users should use the bridge networking option.
 
 The following environment variables are available to you
 
-* `ops_render_config=true` - Use Golang ENV var interpolation to render your JSON configs.
+* `ops_render_config` - Set to `true` to use Golang ENV var interpolation to render your JSON configs.
 
 
 ## Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -172,12 +172,19 @@ handle networking for you.
 
 Only advanced/power users should use the bridge networking option.
 
+## Useful Ops Environment Variables
+
+The following environment variables are available to you
+
+* `ops_render_config=true` - Use Golang ENV var interpolation to render your JSON configs.
+
+
 ## Reporting Bugs
 
 Feel free to open up a pull request. It's helpful to have your OPS
 version and the release channel you are using.
 
-Also, if it doesn't work on the main release, then you can try the nightly. 
+Also, if it doesn't work on the main release, then you can try the nightly.
 The main release can tail the nightly by many weeks sometimes.
 
 ```sh

--- a/cmd/flags_config.go
+++ b/cmd/flags_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -52,8 +53,8 @@ func unWarpConfig(file string, c *types.Config) (err error) {
 	if err != nil {
 		log.Fatalf("error reading config: %v\n", err)
 	}
-
-	return ConvertJSONToConfig(data, c)
+	loadedEnvJSON := os.ExpandEnv(string(data))
+	return ConvertJSONToConfig([]byte(loadedEnvJSON), c)
 }
 
 // ConvertJSONToConfig converts a byte array to an object of type configuration

--- a/cmd/flags_config.go
+++ b/cmd/flags_config.go
@@ -51,10 +51,14 @@ func (flags *ConfigCommandFlags) MergeToConfig(c *types.Config) (err error) {
 func unWarpConfig(file string, c *types.Config) (err error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Fatalf("error reading config: %v\n", err)
+		log.Fatalf("error reading config: %v\nIf you are trying to use interoplation in your\nconfig's JSON set 'ops_render_config=true' in your ENV", err)
 	}
-	loadedEnvJSON := os.ExpandEnv(string(data))
-	return ConvertJSONToConfig([]byte(loadedEnvJSON), c)
+	if os.Getenv("ops_render_config") == "true" {
+		loadedEnvJSON := os.ExpandEnv(string(data))
+		return ConvertJSONToConfig([]byte(loadedEnvJSON), c)
+	} else {
+		return ConvertJSONToConfig(data, c)
+	}
 }
 
 // ConvertJSONToConfig converts a byte array to an object of type configuration

--- a/cmd/flags_config.go
+++ b/cmd/flags_config.go
@@ -56,9 +56,8 @@ func unWarpConfig(file string, c *types.Config) (err error) {
 	if os.Getenv("ops_render_config") == "true" {
 		loadedEnvJSON := os.ExpandEnv(string(data))
 		return ConvertJSONToConfig([]byte(loadedEnvJSON), c)
-	} else {
-		return ConvertJSONToConfig(data, c)
 	}
+	return ConvertJSONToConfig(data, c)
 }
 
 // ConvertJSONToConfig converts a byte array to an object of type configuration


### PR DESCRIPTION
This feature PR allows the JSON configuration file to interpolate environmental variables allowing templating for a multitude of reasons including but not limited to:
* staging versus production deployments
* secrets stored in the JSON file

