### PR TITLE
RunConfig: add support for GPUs

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -203,6 +203,9 @@ type RunConfig struct {
 	// CPUs specifies the number of CPU cores to use
 	CPUs int
 
+	GPUs    int
+	GPUType string
+
 	// Debug
 	Debug bool
 


### PR DESCRIPTION
This change adds 2 new attributes to the RunConfig JSON configuration object:
- GPUs (int): indicates how many GPUs should be attached to an instance (default: 0)
- GPUType (string): type of GPUs to be attached to an instance (cloud provider-specific)

Handling of these configuration option is implemented for the GCP cloud provider; example configuration suited for GCP:
```
  "RunConfig": {
    "GPUs": 1,
    "GPUType": "nvidia-tesla-t4"
  }
```