### PR TITLE
feat(gcp): manage ip forwarding on GCP instance creation

### DIFF
--- a/gcp/gcp_instance.go
+++ b/gcp/gcp_instance.go
@@ -50,6 +50,7 @@ func (p *GCloud) CreateInstance(ctx *lepton.Context) error {
 	}
 
 	instanceName := c.RunConfig.InstanceName
+	canIPForward := c.RunConfig.CanIPForward
 
 	rb := &compute.Instance{
 		Name:        instanceName,
@@ -64,6 +65,7 @@ func (p *GCloud) CreateInstance(ctx *lepton.Context) error {
 				},
 			},
 		},
+		CanIpForward:      canIPForward,
 		NetworkInterfaces: nic,
 		Metadata: &compute.Metadata{
 			Items: []*compute.MetadataItems{

--- a/gcp/gcp_instance_group.go
+++ b/gcp/gcp_instance_group.go
@@ -13,6 +13,7 @@ func (p *GCloud) createInstanceTemplate(ctx *lepton.Context, instanceGroup strin
 	c := ctx.Config()
 
 	instanceName := c.RunConfig.InstanceName
+	canIPForward := c.RunConfig.CanIPForward
 	machineType := c.CloudConfig.Flavor
 
 	imageName := fmt.Sprintf("projects/%v/global/images/%v",
@@ -40,6 +41,7 @@ func (p *GCloud) createInstanceTemplate(ctx *lepton.Context, instanceGroup strin
 					},
 				},
 			},
+			CanIpForward:      canIPForward,
 			NetworkInterfaces: nic,
 			Metadata: &compute.Metadata{
 				Items: []*compute.MetadataItems{

--- a/types/config.go
+++ b/types/config.go
@@ -200,6 +200,9 @@ type RunConfig struct {
 	// BridgeName
 	BridgeName string
 
+	// CanIPForward enable IP forwarding when creating an instance on GCP
+	CanIPForward bool
+
 	// CPUs specifies the number of CPU cores to use
 	CPUs int
 


### PR DESCRIPTION
- [x] added `RunConfig.CanIPForward`
```json
{
  ...
  "RunConfig": {
    "CanIPForward": true
  },
  ...
}
```



- [ ] ops documentation