### PR TITLE
pkg(from-docker): clean returned lib paths

### DIFF
--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -143,7 +143,7 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 			log.Fatalf("Invalid library declaration: %s", libraryLine)
 		}
 
-		libraryPath, libraryDestination := parts[0], sysroot+parts[1]
+		libraryPath, libraryDestination := parts[0], sysroot+path.Clean(parts[1])
 
 		if _, err = os.Stat(libraryDestination); err == nil {
 			continue


### PR DESCRIPTION
clean paths otherwise copy to host fails, ex:
- **from** - `/usr/lib/jvm/java-11-openjdk-amd64/bin/../lib/jli/libjli.so`
- **to**      - `/usr/lib/jvm/java-11-openjdk-amd64/lib/jli/libjli.so`