### PR TITLE
Resolve interpreter's basepath before locating it

### DIFF
--- a/lepton/ldd_darwin.go
+++ b/lepton/ldd_darwin.go
@@ -159,6 +159,7 @@ func _getSharedLibs(libs map[string]string, targetRoot string, path string) erro
 		}
 		// don't include the terminating NUL in path string
 		ipath := string(ipathbuf[:len(ipathbuf)-1])
+		ipath = filepath.Base(ipath)
 		ipath, absIpath, err := findLib(targetRoot, filepath.Dir(path), libDirs, ipath)
 		if err != nil {
 			return errors.WrapPrefix(err, ipath, 0)


### PR DESCRIPTION
If interpreter read from binary is absolute path, then `findLibs` does not locate the interpreter in `libDirs`.

This delta is fixing the issue by resolving the interpreter's base name.