### PR TITLE
GCP: add support for associating a service account to an instance

### DIFF
--- a/gcp/gcp_instance.go
+++ b/gcp/gcp_instance.go
@@ -95,6 +95,14 @@ func (p *GCloud) CreateInstance(ctx *lepton.Context) error {
 			OnHostMaintenance: "TERMINATE",
 		}
 	}
+	if c.CloudConfig.InstanceProfile != "" {
+		rb.ServiceAccounts = []*compute.ServiceAccount{
+			{
+				Email:  c.CloudConfig.InstanceProfile,
+				Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
+			},
+		}
+	}
 	op, err := p.Service.Instances.Insert(c.CloudConfig.ProjectID, c.CloudConfig.Zone, rb).Context(context.TODO()).Do()
 	if err != nil {
 		return err


### PR DESCRIPTION
When executing the `ops instance create` command to create a GCP instance, if the CloudConfig.InstanceProfile configuration parameter is a non-empty string, the instance being created is associated to the service account identified by this string, with `cloud-platform` access scope. GCP service accounts are identified by an email address; the special string "default" indicates the default service account for a given project.
The service account specified in the configuration must exist in the GCP project when an instance is being created, otherwise an error is returned.
For more information about GCP service accounts, see https://cloud.google.com/compute/docs/access/service-accounts.