### PR TITLE
Allow LD_LIBRARY_PATH read from config

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -344,7 +344,7 @@ func BuildManifest(c *types.Config) (*fs.Manifest, error) {
 		return nil, errors.Wrap(err, 1)
 	}
 
-	deps, err := getSharedLibs(c.TargetRoot, c.Program)
+	deps, err := getSharedLibs(c.TargetRoot, c.Program, c)
 	if err != nil {
 		return nil, errors.Wrap(err, 1)
 	}

--- a/lepton/ldd_freebsd.go
+++ b/lepton/ldd_freebsd.go
@@ -3,6 +3,7 @@ package lepton
 import (
 	"debug/elf"
 	"errors"
+	"github.com/nanovms/ops/types"
 )
 
 // GetElfFileInfo returns an object with elf information of the path program
@@ -22,7 +23,7 @@ func IsDynamicLinked(efd *elf.File) bool {
 
 // works only on linux, need to
 // replace looking up in dynamic section in ELF
-func getSharedLibs(targetRoot string, path string) (map[string]string, error) {
+func getSharedLibs(targetRoot string, path string, c *types.Config) (map[string]string, error) {
 	return nil, nil
 }
 

--- a/lepton/ldd_linux.go
+++ b/lepton/ldd_linux.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-errors/errors"
+	"github.com/nanovms/ops/types"
 )
 
 // GetElfFileInfo returns an object with elf information of the path program
@@ -47,7 +48,7 @@ func IsDynamicLinked(efd *elf.File) bool {
 
 // works only on linux, need to
 // replace looking up in dynamic section in ELF
-func getSharedLibs(targetRoot string, path string) (map[string]string, error) {
+func getSharedLibs(targetRoot string, path string, c *types.Config) (map[string]string, error) {
 	var notExistLib []string
 	var absTargetRoot string
 	if targetRoot != "" {

--- a/lepton/ldd_windows.go
+++ b/lepton/ldd_windows.go
@@ -3,6 +3,7 @@ package lepton
 import (
 	"debug/elf"
 	"errors"
+	"github.com/nanovms/ops/types"
 )
 
 // IsDynamicLinked stub
@@ -21,7 +22,7 @@ func GetElfFileInfo(path string) (*elf.File, error) {
 }
 
 // stub
-func getSharedLibs(targetRoot string, path string) (map[string]string, error) {
+func getSharedLibs(targetRoot string, path string, c *types.Config) (map[string]string, error) {
 	var deps = make(map[string]string)
 	return deps, nil
 }


### PR DESCRIPTION
Currently we support reading LD_LIBRARY_PATH from host and from ELF section. This PR adds third option to read from config to improve the command-line experience.
```sh
# before
$ LD_LIBRARY_PATH=/tmp/linux/lib:/tmp/linux/usr/lib:/tmp/linux/lib/x86_64-linux-gnu:/tmp/linux/usr/lib/x86_64-linux-gnu \
    ops run -c config.json publish/myApp
```
```sh
# after: config.json has the Env section:
#    "Env": {
#      "LD_LIBRARY_PATH": "/tmp/linux/lib:/tmp/linux/usr/lib:/tmp/linux/lib/x86_64-linux-gnu:/tmp/linux/usr/lib/x86_64-linux-gnu"
#    }

$ ops run -c config.json publish/myApp
```