### PR TITLE
config(manifest): omit most of empty config items

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -3,180 +3,180 @@ package types
 // Config for Build
 type Config struct {
 	// Args defines an array of commands to execute when the image is launched.
-	Args []string
+	Args []string `json:",omitempty"`
 
 	// Disable auto copy of files from host to container when present in args
-	DisableArgsCopy bool
+	DisableArgsCopy bool `json:",omitempty"`
 
 	// BaseVolumeSz is an optional parameter for defining the size of the base
 	// volume (defaults to the end of blocks written by TFS).
-	BaseVolumeSz string
+	BaseVolumeSz string `json:",omitempty"`
 
 	// Boot
-	Boot string
+	Boot string `json:",omitempty"`
 
 	// Boot path of UEFI bootloader file
-	UefiBoot string
+	UefiBoot string `json:",omitempty"`
 
 	// Uefi indicates whether image should support booting via UEFI
-	Uefi bool
+	Uefi bool `json:",omitempty"`
 
 	// BuildDir
-	BuildDir string
+	BuildDir string `json:",omitempty"`
 
 	// CloudConfig configures various attributes about the cloud provider.
-	CloudConfig ProviderConfig
+	CloudConfig ProviderConfig `json:",omitempty"`
 
 	// TargetConfig allows config that is pertinent to a specific
 	// provider.
-	TargetConfig map[string]string
+	TargetConfig map[string]string `json:",omitempty"`
 
 	// Debugflags
-	Debugflags []string
+	Debugflags []string `json:",omitempty"`
 
 	// Dirs defines an array of directory locations to include into the image.
-	Dirs []string
+	Dirs []string `json:",omitempty"`
 
 	// Env defines a map of environment variables to specify for the image
 	// runtime.
-	Env map[string]string
+	Env map[string]string `json:",omitempty"`
 
 	// Files defines an array of file locations to include into the image.
-	Files []string
+	Files []string `json:",omitempty"`
 
 	// Force
-	Force bool
+	Force bool `json:",omitempty"`
 
 	// Kernel
-	Kernel string
+	Kernel string `json:",omitempty"`
 
 	// Klibs host location
-	KlibDir string
+	KlibDir string `json:",omitempty"`
 
 	// MapDirs specifies a map of local directories to add to into the image.
 	// These directory paths are then adjusted from local path specification
 	// to image path specification.
-	MapDirs map[string]string
+	MapDirs map[string]string `json:",omitempty"`
 
 	// Mounts
-	Mounts map[string]string
+	Mounts map[string]string `json:",omitempty"`
 
 	// NameServers is an optional parameter array that defines the DNS server to use
 	// for DNS resolutions (defaults to Google's DNS server: '8.8.8.8').
-	NameServers []string
+	NameServers []string `json:",omitempty"`
 
 	// NanosVersion
-	NanosVersion string
+	NanosVersion string `json:",omitempty"`
 
 	// NightlyBuild
-	NightlyBuild bool
+	NightlyBuild bool `json:",omitempty"`
 
 	// NoTrace
-	NoTrace []string
+	NoTrace []string `json:",omitempty"`
 
 	// Straight passthrough of options to manifest
-	ManifestPassthrough map[string]interface{}
+	ManifestPassthrough map[string]interface{} `json:",omitempty"`
 
 	// Program
-	Program string
+	Program string `json:",omitempty"`
 
 	// ProgramPath specifies the original path of the program to refer to on
 	// attach/detach.
-	ProgramPath string
+	ProgramPath string `json:",omitempty"`
 
 	// RebootOnExit defines whether the image should automatically reboot
 	// if an error/failure occurs.
-	RebootOnExit bool
+	RebootOnExit bool `json:",omitempty"`
 
 	// RunConfig
-	RunConfig RunConfig
+	RunConfig RunConfig `json:",omitempty"`
 
 	// LocalFilesParentDirectory is the parent directory of the files/directories specified in Files and Dirs
 	// The default value is the directory from where the ops command is running
-	LocalFilesParentDirectory string
+	LocalFilesParentDirectory string `json:",omitempty"`
 
 	// TargetRoot
-	TargetRoot string
+	TargetRoot string `json:",omitempty"`
 
 	// Version
-	Version string
+	Version string `json:",omitempty"`
 
 	// Language
-	Language string
+	Language string `json:",omitempty"`
 
 	// Runtime
-	Runtime string
+	Runtime string `json:",omitempty"`
 
 	// Description
-	Description string
+	Description string `json:",omitempty"`
 
 	// VolumesDir is the directory used to store and fetch volumes
-	VolumesDir string
+	VolumesDir string `json:",omitempty"`
 
 	// PackageBaseURL gives URL for downloading of packages
-	PackageBaseURL string
+	PackageBaseURL string `json:",omitempty"`
 
 	// PackageManifestURL stores info about all packages
-	PackageManifestURL string
+	PackageManifestURL string `json:",omitempty"`
 }
 
 // ProviderConfig give provider details
 type ProviderConfig struct {
 
 	// BucketName specifies the bucket to store the ops built image artifacts.
-	BucketName string `cloud:"bucketname"`
+	BucketName string `cloud:"bucketname" json:",omitempty"`
 
 	// BucketNamespace is required on uploading files to cloud providers as oci
-	BucketNamespace string
+	BucketNamespace string `json:",omitempty"`
 
 	// DomainName
-	DomainName string
+	DomainName string `json:",omitempty"`
 
 	// Used by cloud provider to assign a public static IP to a NIC
-	StaticIP string
+	StaticIP string `json:",omitempty"`
 
 	// EnableIPv6 enables IPv6 when creating a vpc. It does not affect an existing VPC
-	EnableIPv6 bool
+	EnableIPv6 bool `json:",omitempty"`
 
 	// Flavor
-	Flavor string `cloud:"flavor"`
+	Flavor string `cloud:"flavor" json:",omitempty"`
 
 	// ImageType
-	ImageType string `cloud:"imagetype"`
+	ImageType string `cloud:"imagetype" json:",omitempty"`
 
 	// ImageName
-	ImageName string `cloud:"imagename"`
+	ImageName string `cloud:"imagename" json:",omitempty"`
 
 	// InstanceProfile is a container for an IAM role
 	// you can use to pass role information to an EC2 instance when the instance starts.
-	InstanceProfile string
+	InstanceProfile string `json:",omitempty"`
 
 	// Platform defines the cloud provider to use with the ops CLI, currently
 	// supporting aws, azure, and gcp.
-	Platform string `cloud:"platform"`
+	Platform string `cloud:"platform" json:",omitempty"`
 
 	// ProjectID is used to define the project ID when the Platform is set
 	// to gcp.
-	ProjectID string `cloud:"projectid"`
+	ProjectID string `cloud:"projectid" json:",omitempty"`
 
 	// SecurityGroup
-	SecurityGroup string
+	SecurityGroup string `json:",omitempty"`
 
 	// Subnet
-	Subnet string
+	Subnet string `json:",omitempty"`
 
 	// Tags
-	Tags []Tag
+	Tags []Tag `json:",omitempty"`
 
 	// VPC
-	VPC string
+	VPC string `json:",omitempty"`
 
 	// Zone is used to define the location of the host resource. Lists of these
 	// zones are dependent on selected Platform and can be found here:
 	// aws: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 	// azure: https://azure.microsoft.com/en-us/global-infrastructure/geographies/#overview
 	// gcp: https://cloud.google.com/compute/docs/regions-zones#available
-	Zone string `cloud:"zone"`
+	Zone string `cloud:"zone" json:",omitempty"`
 }
 
 // Tag is used as property on creating instances
@@ -191,119 +191,119 @@ type Tag struct {
 // RunConfig provides runtime details
 type RunConfig struct {
 	// Accel defines whether hardware acceleration should be enabled.
-	Accel bool
+	Accel bool `json:",omitempty"`
 
 	// Bridged parameter is set to true if bridged networking mode is
 	// in use. This also enables KVM acceleration.
-	Bridged bool
+	Bridged bool `json:",omitempty"`
 
 	// BridgeName
-	BridgeName string
+	BridgeName string `json:",omitempty"`
 
 	// CanIPForward enable IP forwarding when creating an instance on GCP
-	CanIPForward bool
+	CanIPForward bool `json:",omitempty"`
 
 	// CPUs specifies the number of CPU cores to use
-	CPUs int
+	CPUs int `json:",omitempty"`
 
-	GPUs    int
-	GPUType string
+	GPUs    int    `json:",omitempty"`
+	GPUType string `json:",omitempty"`
 
 	// Debug
-	Debug bool
+	Debug bool `json:",omitempty"`
 
 	// Gateway
-	Gateway string
+	Gateway string `json:",omitempty"`
 
 	// GdbPort
-	GdbPort int
+	GdbPort int `json:",omitempty"`
 
 	// Imagename (FIXME)
-	Imagename string
+	Imagename string `json:",omitempty"`
 
 	// InstanceGroup
-	InstanceGroup string
+	InstanceGroup string `json:",omitempty"`
 
 	// InstanceName
-	InstanceName string
+	InstanceName string `json:",omitempty"`
 
 	// IPAddress
-	IPAddress string
+	IPAddress string `json:",omitempty"`
 
 	// IPv6Address
-	IPv6Address string
+	IPv6Address string `json:",omitempty"`
 
 	// Klibs
-	Klibs []string
+	Klibs []string `json:",omitempty"`
 
 	// Memory configures the amount of memory to allocate to qemu (default
 	// is 128 MiB). Optionally, a suffix of "M" or "G" can be used to
 	// signify a value in megabytes or gigabytes respectively.
-	Memory string
+	Memory string `json:",omitempty"`
 
 	// Vga whether to emulate a VGA output device
-	Vga bool
+	Vga bool `json:",omitempty"`
 
 	// Mounts
-	Mounts []string
+	Mounts []string `json:",omitempty"`
 
 	// NetMask
-	NetMask string
+	NetMask string `json:",omitempty"`
 
 	// Nics is a list of pre-configured network cards
 	// Meant to eventually deprecate the existing single-nic configuration
 	// Currently only supported for Proxmox
-	Nics []Nic
+	Nics []Nic `json:",omitempty"`
 
 	// Background runs unikernel in background
 	// use onprem instances commands to manage the unikernel
-	Background bool
+	Background bool `json:",omitempty"`
 
 	// Ports specifies a list of port to expose.
-	Ports []string
+	Ports []string `json:",omitempty"`
 
 	// ShowDebug
-	ShowDebug bool
+	ShowDebug bool `json:",omitempty"`
 
 	// ShowErrors
-	ShowErrors bool
+	ShowErrors bool `json:",omitempty"`
 
 	// ShowWarnings
-	ShowWarnings bool
+	ShowWarnings bool `json:",omitempty"`
 
 	// JSON output
-	JSON bool
+	JSON bool `json:",omitempty"`
 
 	// TapName
-	TapName string
+	TapName string `json:",omitempty"`
 
 	// UDPPorts
-	UDPPorts []string
+	UDPPorts []string `json:",omitempty"`
 
 	// Verbose enables logging for the runtime environment.
-	Verbose bool
+	Verbose bool `json:",omitempty"`
 
 	// VolumeSizeInGb is an optional parameter only available for OpenStack.
-	VolumeSizeInGb int
+	VolumeSizeInGb int `json:",omitempty"`
 }
 
 // Nic describes a nic
 // Currently only supported for Proxmox
 type Nic struct {
 	// IPAddress
-	IPAddress string
+	IPAddress string `json:",omitempty"`
 
 	// IPv6Address
-	IPv6Address string
+	IPv6Address string `json:",omitempty"`
 
 	// NetMask
-	NetMask string
+	NetMask string `json:",omitempty"`
 
 	// Gateway
-	Gateway string
+	Gateway string `json:",omitempty"`
 
 	// BridgeName
-	BridgeName string
+	BridgeName string `json:",omitempty"`
 }
 
 // RuntimeConfig constructs runtime config


### PR DESCRIPTION
Instead of getting all config items on manifest, we want just what is configured/set.

- **right now we have:**
```json
{
  "Args": [
    "node"
  ],
  "DisableArgsCopy": false,
  "BaseVolumeSz": "",
  "Boot": "",
  "UefiBoot": "",
  "Uefi": false,
  "BuildDir": "",
  "CloudConfig": {
    "BucketName": "",
    "BucketNamespace": "",
    "DomainName": "",
    "StaticIP": "",
    "EnableIPv6": false,
    "Flavor": "",
    "ImageType": "",
    "ImageName": "",
    "InstanceProfile": "",
    "Platform": "",
    "ProjectID": "",
    "SecurityGroup": "",
    "Subnet": "",
    "Tags": null,
    "VPC": "",
    "Zone": ""
  },
  "TargetConfig": null,
  "Debugflags": null,
  "Dirs": null,
  "Env": null,
  "Files": null,
  "Force": false,
  "Kernel": "",
  "KlibDir": "",
  "MapDirs": null,
  "Mounts": null,
  "NameServers": null,
  "NanosVersion": "",
  "NightlyBuild": false,
  "NoTrace": null,
  "ManifestPassthrough": null,
  "Program": "mypkg_0.0.1/node",
  "ProgramPath": "",
  "RebootOnExit": false,
  "RunConfig": {
    "Accel": false,
    "Bridged": false,
    "BridgeName": "",
    "CanIPForward": false,
    "CPUs": 0,
    "GPUs": 0,
    "GPUType": "",
    "Debug": false,
    "Gateway": "",
    "GdbPort": 0,
    "Imagename": "",
    "InstanceGroup": "",
    "InstanceName": "",
    "IPAddress": "",
    "IPv6Address": "",
    "Klibs": null,
    "Memory": "",
    "Vga": false,
    "Mounts": null,
    "NetMask": "",
    "Nics": null,
    "Background": false,
    "Ports": null,
    "ShowDebug": false,
    "ShowErrors": false,
    "ShowWarnings": false,
    "JSON": false,
    "TapName": "",
    "UDPPorts": null,
    "Verbose": false,
    "VolumeSizeInGb": 0
  },
  "LocalFilesParentDirectory": "",
  "TargetRoot": "",
  "Version": "0.0.1",
  "Language": "",
  "Runtime": "",
  "Description": "",
  "VolumesDir": "",
  "PackageBaseURL": "",
  "PackageManifestURL": ""
}
```

- **desired output:** 
```json
{
  "Args": [
    "node"
  ],
  "Program": "mypkg_0.0.1/node",
  "Version": "0.0.1"
}
```
- **what this pr provides:**
```json
{
  "Args": [
    "node"
  ],
  "CloudConfig": {},
  "Program": "mypkg_0.0.1/node",
  "RunConfig": {},
  "Version": "0.0.1"
}
```
Can take care of removing also `"CloudConfig"` and `"RunConfig"`, but not sure if it's worth it.