### PR TITLE
add global json flag support for listing do images and instances

### DIFF
--- a/digitalocean/digital_ocean_image.go
+++ b/digitalocean/digital_ocean_image.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -99,6 +100,9 @@ func (do *DigitalOcean) ListImages(ctx *lepton.Context) error {
 	images, err := do.GetImages(ctx)
 	if err != nil {
 		return err
+	}
+	if ctx.Config().RunConfig.JSON {
+		return json.NewEncoder(os.Stdout).Encode(images)
 	}
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"Name", "Status", "Created"})

--- a/digitalocean/digital_ocean_instance.go
+++ b/digitalocean/digital_ocean_instance.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -138,6 +139,9 @@ func (do *DigitalOcean) ListInstances(ctx *lepton.Context) error {
 	instances, err := do.GetInstances(ctx)
 	if err != nil {
 		return err
+	}
+	if ctx.Config().RunConfig.JSON {
+		return json.NewEncoder(os.Stdout).Encode(instances)
 	}
 	// print list of images in table
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
Hey, this is a continuation of https://github.com/nanovms/ops/pull/1240 that enabled the DO list instances and images commands to use the global `--json` flag.

I'm just playing around with ops, and needed json support for do commands, and it seemed easier to make a PR than make a ticket to ask for support for this in DO, hope that's ok.

~geoah