### PR TITLE
On premises instance: add support for VirtFS (9P filesystem)

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -15,6 +15,7 @@ import (
 
 	api "github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/log"
+	"github.com/nanovms/ops/provider/onprem"
 	"github.com/nanovms/ops/types"
 
 	"github.com/go-errors/errors"
@@ -577,6 +578,13 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 		executableName = filepath.Join(api.PackageSysRootFolderName, executableName)
 	}
 	api.ValidateELF(filepath.Join(pkgFlags.PackagePath(), executableName))
+
+	if c.Mounts != nil {
+		err = onprem.AddVirtfsShares(c)
+		if err != nil {
+			exitWithError("Failed to add VirtFS shares: " + err.Error())
+		}
+	}
 
 	if !runLocalInstanceFlags.SkipBuild {
 		if err = api.BuildImageFromPackage(pkgFlags.PackagePath(), *c); err != nil {

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nanovms/ops/lepton"
 	api "github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/provider/onprem"
 	"github.com/spf13/cobra"
 )
 
@@ -56,6 +57,13 @@ func runCommandHandler(cmd *cobra.Command, args []string) {
 	err = mergeContainer.Merge(c)
 	if err != nil {
 		exitWithError(err.Error())
+	}
+
+	if c.Mounts != nil {
+		err = onprem.AddVirtfsShares(c)
+		if err != nil {
+			exitWithError("Failed to add VirtFS shares: " + err.Error())
+		}
 	}
 
 	if !runLocalInstanceFlags.SkipBuild {

--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -387,10 +387,17 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) {
 
 	q.addOption("-device", "virtio-rng-pci")
 
+	disks := 1
+	for _, hostDir := range rconfig.VirtfsShares {
+		q.addOption("-virtfs", fmt.Sprintf("local,path=%s,mount_tag=%d,security_model=none,multidevs=remap,id=hd%d", hostDir, disks, disks))
+		disks++
+	}
+
 	// add mounted volumes
-	for n, file := range rconfig.Mounts {
-		q.addDrive(fmt.Sprintf("hd%d", n+1), file, "none")
-		q.addOption("-device", fmt.Sprintf("scsi-hd,bus=scsi0.0,drive=hd%d", n+1))
+	for _, file := range rconfig.Mounts {
+		q.addDrive(fmt.Sprintf("hd%d", disks), file, "none")
+		q.addOption("-device", fmt.Sprintf("scsi-hd,bus=scsi0.0,drive=hd%d", disks))
+		disks++
 	}
 
 	netDevType := "user"

--- a/types/config.go
+++ b/types/config.go
@@ -247,6 +247,9 @@ type RunConfig struct {
 	// Vga whether to emulate a VGA output device
 	Vga bool `json:",omitempty"`
 
+	// host directories shared with guest via VirtFS
+	VirtfsShares []string `json:",omitempty"`
+
 	// Mounts
 	Mounts []string `json:",omitempty"`
 


### PR DESCRIPTION
This change adds support for exporting host folders to the guest when running a local instance. Handling of the mount configuration options is being amended so that if there are no local volumes matching a label in a mount directive, a folder in the host filesystem is exported to the guest via VirtFS instead of using a pre-made volume.
This new functionality can be used in the 'run' and 'pkg load' commands, both as a command line option (e.g.
'--mounts host_dir:/guest_dir') and as a JSON attribute in the configuration file.