### PR TITLE
build(provider): add build tags to disable providers

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (

--- a/provider/aws/aws_dns.go
+++ b/provider/aws/aws_dns.go
@@ -1,14 +1,15 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (
 	"strconv"
 	"time"
 
-	"github.com/nanovms/ops/types"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/types"
 )
 
 // FindOrCreateZoneIDByName searches for a DNS zone with the name passed by argument and if it doesn't exist it creates one

--- a/provider/aws/aws_image.go
+++ b/provider/aws/aws_image.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (
@@ -24,7 +26,6 @@ import (
 	"github.com/nanovms/ops/log"
 	"github.com/nanovms/ops/types"
 	"github.com/olekukonko/tablewriter"
-
 	"github.com/schollz/progressbar/v3"
 )
 

--- a/provider/aws/aws_image_test.go
+++ b/provider/aws/aws_image_test.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws_test
 
 import (

--- a/provider/aws/aws_instance.go
+++ b/provider/aws/aws_instance.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (

--- a/provider/aws/aws_instance_group.go
+++ b/provider/aws/aws_instance_group.go
@@ -1,7 +1,10 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/provider/aws/aws_network.go
+++ b/provider/aws/aws_network.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (

--- a/provider/aws/aws_store.go
+++ b/provider/aws/aws_store.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (
@@ -5,14 +7,13 @@ import (
 	"math"
 	"os"
 
-	"github.com/nanovms/ops/log"
-	"github.com/nanovms/ops/types"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/nanovms/ops/log"
+	"github.com/nanovms/ops/types"
 )
 
 // S3 provides AWS storage related operations

--- a/provider/aws/aws_volume.go
+++ b/provider/aws/aws_volume.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (

--- a/provider/aws/provider_disabled.go
+++ b/provider/aws/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !aws && onlyprovider
+
+package aws
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "aws"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/aws/role.go
+++ b/provider/aws/role.go
@@ -1,3 +1,5 @@
+//go:build aws || !onlyprovider
+
 package aws
 
 import (

--- a/provider/azure/azure.go
+++ b/provider/azure/azure.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (
@@ -8,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-12-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -16,8 +19,6 @@ import (
 	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/log"
 	"github.com/nanovms/ops/types"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-12-01/compute"
 )
 
 // ProviderName of the cloud platform provider

--- a/provider/azure/azure_dns.go
+++ b/provider/azure/azure_dns.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/azure_image.go
+++ b/provider/azure/azure_image.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/azure_instance.go
+++ b/provider/azure/azure_instance.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/azure_network.go
+++ b/provider/azure/azure_network.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/azure_network_test.go
+++ b/provider/azure/azure_network_test.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import "testing"

--- a/provider/azure/azure_store.go
+++ b/provider/azure/azure_store.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/azure_volume.go
+++ b/provider/azure/azure_volume.go
@@ -1,3 +1,5 @@
+//go:build azure || !onlyprovider
+
 package azure
 
 import (

--- a/provider/azure/provider_disabled.go
+++ b/provider/azure/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !azure && onlyprovider
+
+package azure
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "azure"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/digitalocean/digital_ocean.go
+++ b/provider/digitalocean/digital_ocean.go
@@ -1,6 +1,9 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/digitalocean/godo"
@@ -25,6 +28,9 @@ func NewProvider() *DigitalOcean {
 // Initialize DigialOcean related things
 func (do *DigitalOcean) Initialize(c *types.ProviderConfig) error {
 	doToken := os.Getenv("DO_TOKEN")
+	if doToken == "" {
+		return fmt.Errorf("set DO_TOKEN")
+	}
 	do.Client = godo.NewFromToken(doToken)
 	return nil
 }

--- a/provider/digitalocean/digital_ocean_image.go
+++ b/provider/digitalocean/digital_ocean_image.go
@@ -1,3 +1,5 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import (

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -1,3 +1,5 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import (

--- a/provider/digitalocean/digital_ocean_store.go
+++ b/provider/digitalocean/digital_ocean_store.go
@@ -1,3 +1,5 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import (

--- a/provider/digitalocean/digital_ocean_test.go
+++ b/provider/digitalocean/digital_ocean_test.go
@@ -1,3 +1,5 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import (

--- a/provider/digitalocean/digital_ocean_volume.go
+++ b/provider/digitalocean/digital_ocean_volume.go
@@ -1,3 +1,5 @@
+//go:build digitalocean || do || !onlyprovider
+
 package digitalocean
 
 import "github.com/nanovms/ops/lepton"

--- a/provider/digitalocean/provider_disabled.go
+++ b/provider/digitalocean/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !(digitalocean || do) && onlyprovider
+
+package digitalocean
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "do"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/disabled/provider_disabled.go
+++ b/provider/disabled/provider_disabled.go
@@ -1,0 +1,140 @@
+//go:build !(aws && azure && (digitalocean || do) && gcp && hyperv && ibm && linode && oci && openshift && openstack && proxmox && upcloud && vbox && vsphere && vultr) && onlyprovider
+
+package disabled
+
+import (
+	"fmt"
+
+	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/types"
+)
+
+// Provider ...
+type Provider struct {
+	name string
+}
+
+// NewProvider ...
+func NewProvider(name string) *Provider {
+	return &Provider{name}
+}
+
+// Initialize ...
+func (p *Provider) Initialize(config *types.ProviderConfig) error {
+	return fmt.Errorf("[%s] provider - disabled", p.name)
+}
+
+// BuildImage ...
+func (p *Provider) BuildImage(ctx *lepton.Context) (string, error) {
+	return "", nil
+}
+
+// BuildImageWithPackage ...
+func (p *Provider) BuildImageWithPackage(ctx *lepton.Context, pkgpath string) (string, error) {
+	return "", nil
+}
+
+// CreateImage ...
+func (p *Provider) CreateImage(ctx *lepton.Context, imagePath string) error {
+	return nil
+}
+
+// ListImages ...
+func (p *Provider) ListImages(ctx *lepton.Context) error {
+	return nil
+}
+
+// GetImages ...
+func (p *Provider) GetImages(ctx *lepton.Context) ([]lepton.CloudImage, error) {
+	return nil, nil
+}
+
+// DeleteImage ...
+func (p *Provider) DeleteImage(ctx *lepton.Context, imagename string) error {
+	return nil
+}
+
+// ResizeImage ...
+func (p *Provider) ResizeImage(ctx *lepton.Context, imagename string, hbytes string) error {
+	return nil
+}
+
+// SyncImage ...
+func (p *Provider) SyncImage(config *types.Config, target lepton.Provider, imagename string) error {
+	return nil
+}
+
+// CustomizeImage ...
+func (p *Provider) CustomizeImage(ctx *lepton.Context) (string, error) {
+	return "", nil
+}
+
+// CreateInstance ...
+func (p *Provider) CreateInstance(ctx *lepton.Context) error {
+	return nil
+}
+
+// ListInstances ...
+func (p *Provider) ListInstances(ctx *lepton.Context) error {
+	return nil
+}
+
+// GetInstances ...
+func (p *Provider) GetInstances(ctx *lepton.Context) ([]lepton.CloudInstance, error) {
+	return nil, nil
+}
+
+// GetInstanceByName ...
+func (p *Provider) GetInstanceByName(ctx *lepton.Context, name string) (*lepton.CloudInstance, error) {
+	return nil, nil
+}
+
+// DeleteInstance ...
+func (p *Provider) DeleteInstance(ctx *lepton.Context, instancename string) error {
+	return nil
+}
+
+// StopInstance ...
+func (p *Provider) StopInstance(ctx *lepton.Context, instancename string) error {
+	return nil
+}
+
+// StartInstance ...
+func (p *Provider) StartInstance(ctx *lepton.Context, instancename string) error {
+	return nil
+}
+
+// GetInstanceLogs ...
+func (p *Provider) GetInstanceLogs(ctx *lepton.Context, instancename string) (string, error) {
+	return "", nil
+}
+
+// PrintInstanceLogs ...
+func (p *Provider) PrintInstanceLogs(ctx *lepton.Context, instancename string, watch bool) error {
+	return nil
+}
+
+// CreateVolume ...
+func (p *Provider) CreateVolume(ctx *lepton.Context, volumeName, data, provider string) (lepton.NanosVolume, error) {
+	return lepton.NanosVolume{}, nil
+}
+
+// GetAllVolumes ...
+func (p *Provider) GetAllVolumes(ctx *lepton.Context) (*[]lepton.NanosVolume, error) {
+	return nil, nil
+}
+
+// DeleteVolume ...
+func (p *Provider) DeleteVolume(ctx *lepton.Context, volumeName string) error {
+	return nil
+}
+
+// AttachVolume ...
+func (p *Provider) AttachVolume(ctx *lepton.Context, instanceName, volumeName string, attachID int) error {
+	return nil
+}
+
+// DetachVolume ...
+func (p *Provider) DetachVolume(ctx *lepton.Context, instanceName, volumeName string) error {
+	return nil
+}

--- a/provider/gcp/gcp.go
+++ b/provider/gcp/gcp.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_dns.go
+++ b/provider/gcp/gcp_dns.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_image.go
+++ b/provider/gcp/gcp_image.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_instance.go
+++ b/provider/gcp/gcp_instance.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_instance_group.go
+++ b/provider/gcp/gcp_instance_group.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_network.go
+++ b/provider/gcp/gcp_network.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_store.go
+++ b/provider/gcp/gcp_store.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/gcp_volume.go
+++ b/provider/gcp/gcp_volume.go
@@ -1,3 +1,5 @@
+//go:build gcp || !onlyprovider
+
 package gcp
 
 import (

--- a/provider/gcp/provider_disabled.go
+++ b/provider/gcp/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !gcp && onlyprovider
+
+package gcp
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "gcp"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/hyperv/hyperv.go
+++ b/provider/hyperv/hyperv.go
@@ -1,3 +1,5 @@
+//go:build hyperv || !onlyprovider
+
 package hyperv
 
 import (

--- a/provider/hyperv/hyperv_api.go
+++ b/provider/hyperv/hyperv_api.go
@@ -1,3 +1,5 @@
+//go:build hyperv || !onlyprovider
+
 package hyperv
 
 import (

--- a/provider/hyperv/hyperv_image.go
+++ b/provider/hyperv/hyperv_image.go
@@ -1,3 +1,5 @@
+//go:build hyperv || !onlyprovider
+
 package hyperv
 
 import (

--- a/provider/hyperv/hyperv_instance.go
+++ b/provider/hyperv/hyperv_instance.go
@@ -1,3 +1,5 @@
+//go:build hyperv || !onlyprovider
+
 package hyperv
 
 import (

--- a/provider/hyperv/powershell.go
+++ b/provider/hyperv/powershell.go
@@ -1,3 +1,5 @@
+//go:build hyperv || !onlyprovider
+
 package hyperv
 
 import (

--- a/provider/hyperv/provider_disabled.go
+++ b/provider/hyperv/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !hyperv && onlyprovider
+
+package hyperv
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "hyper-v"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/ibm/ibm.go
+++ b/provider/ibm/ibm.go
@@ -1,3 +1,5 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import (

--- a/provider/ibm/ibm_image.go
+++ b/provider/ibm/ibm_image.go
@@ -1,3 +1,5 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import (

--- a/provider/ibm/ibm_instance.go
+++ b/provider/ibm/ibm_instance.go
@@ -1,3 +1,5 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import (
@@ -13,7 +15,6 @@ import (
 	"time"
 
 	"github.com/nanovms/ops/lepton"
-
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/provider/ibm/ibm_networking.go
+++ b/provider/ibm/ibm_networking.go
@@ -1,3 +1,5 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import (

--- a/provider/ibm/ibm_store.go
+++ b/provider/ibm/ibm_store.go
@@ -1,13 +1,16 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import (
 	"bufio"
 	"fmt"
-	"github.com/nanovms/ops/types"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/nanovms/ops/types"
 )
 
 // Objects represent storage specific information for cloud object

--- a/provider/ibm/ibm_volume.go
+++ b/provider/ibm/ibm_volume.go
@@ -1,3 +1,5 @@
+//go:build ibm || !onlyprovider
+
 package ibm
 
 import "github.com/nanovms/ops/lepton"

--- a/provider/ibm/provider_disabled.go
+++ b/provider/ibm/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !ibm && onlyprovider
+
+package ibm
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "ibm"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/linode/linode.go
+++ b/provider/linode/linode.go
@@ -1,3 +1,5 @@
+//go:build linode || !onlyprovider
+
 package linode
 
 import (

--- a/provider/linode/linode_image.go
+++ b/provider/linode/linode_image.go
@@ -1,3 +1,5 @@
+//go:build linode || !onlyprovider
+
 package linode
 
 import (

--- a/provider/linode/linode_instance.go
+++ b/provider/linode/linode_instance.go
@@ -1,3 +1,5 @@
+//go:build linode || !onlyprovider
+
 package linode
 
 import (
@@ -12,7 +14,6 @@ import (
 	"time"
 
 	"github.com/nanovms/ops/lepton"
-
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/provider/linode/linode_store.go
+++ b/provider/linode/linode_store.go
@@ -1,3 +1,5 @@
+//go:build linode || !onlyprovider
+
 package linode
 
 import (

--- a/provider/linode/linode_volume.go
+++ b/provider/linode/linode_volume.go
@@ -1,3 +1,5 @@
+//go:build linode || !onlyprovider
+
 package linode
 
 import "github.com/nanovms/ops/lepton"

--- a/provider/linode/provider_disabled.go
+++ b/provider/linode/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !linode && onlyprovider
+
+package linode
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "linode"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 
 package oci

--- a/provider/oci/oci_image.go
+++ b/provider/oci/oci_image.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci
 
 import (

--- a/provider/oci/oci_image_test.go
+++ b/provider/oci/oci_image_test.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci_test
 
 import (

--- a/provider/oci/oci_instance.go
+++ b/provider/oci/oci_instance.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci
 
 import (

--- a/provider/oci/oci_instance_test.go
+++ b/provider/oci/oci_instance_test.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci_test
 
 import (

--- a/provider/oci/oci_network.go
+++ b/provider/oci/oci_network.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci
 
 import (

--- a/provider/oci/oci_test.go
+++ b/provider/oci/oci_test.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci_test
 
 import (

--- a/provider/oci/oci_volume.go
+++ b/provider/oci/oci_volume.go
@@ -1,3 +1,5 @@
+//go:build oci || !onlyprovider
+
 package oci
 
 import (

--- a/provider/oci/provider_disabled.go
+++ b/provider/oci/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !oci && onlyprovider
+
+package oci
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "oci"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/openshift/kclient.go
+++ b/provider/openshift/kclient.go
@@ -1,3 +1,5 @@
+//go:build openshift || !onlyprovider
+
 package openshift
 
 import (

--- a/provider/openshift/provider.go
+++ b/provider/openshift/provider.go
@@ -1,3 +1,5 @@
+//go:build openshift || !onlyprovider
+
 package openshift
 
 import (

--- a/provider/openshift/provider_disabled.go
+++ b/provider/openshift/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !openshift && onlyprovider
+
+package openshift
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "openshift"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/openshift/utils.go
+++ b/provider/openshift/utils.go
@@ -1,3 +1,5 @@
+//go:build openshift || !onlyprovider
+
 package openshift
 
 import (

--- a/provider/openstack/openstack.go
+++ b/provider/openstack/openstack.go
@@ -1,3 +1,5 @@
+//go:build openstack || !onlyprovider
+
 package openstack
 
 import (
@@ -5,12 +7,11 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/nanovms/ops/log"
 	"github.com/nanovms/ops/types"
-
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 )
 
 // ProviderName of the cloud platform provider

--- a/provider/openstack/openstack_dns.go
+++ b/provider/openstack/openstack_dns.go
@@ -1,3 +1,5 @@
+//go:build openstack || !onlyprovider
+
 package openstack
 
 import (

--- a/provider/openstack/openstack_image.go
+++ b/provider/openstack/openstack_image.go
@@ -1,3 +1,5 @@
+//go:build openstack || !onlyprovider
+
 package openstack
 
 import (

--- a/provider/openstack/openstack_instance.go
+++ b/provider/openstack/openstack_instance.go
@@ -1,3 +1,5 @@
+//go:build openstack || !onlyprovider
+
 package openstack
 
 import (

--- a/provider/openstack/openstack_volume.go
+++ b/provider/openstack/openstack_volume.go
@@ -1,3 +1,5 @@
+//go:build openstack || !onlyprovider
+
 package openstack
 
 import (
@@ -7,14 +9,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/nanovms/ops/lepton"
-	"github.com/nanovms/ops/log"
-
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/log"
 )
 
 func (o *OpenStack) getVolumesClient() (*gophercloud.ServiceClient, error) {

--- a/provider/openstack/provider_disabled.go
+++ b/provider/openstack/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !openstack && onlyprovider
+
+package openstack
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "openstack"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/proxmox/provider_disabled.go
+++ b/provider/proxmox/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !proxmox && onlyprovider
+
+package proxmox
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "proxmox"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/proxmox/proxmox.go
+++ b/provider/proxmox/proxmox.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import (

--- a/provider/proxmox/proxmox_checks.go
+++ b/provider/proxmox/proxmox_checks.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import (

--- a/provider/proxmox/proxmox_image.go
+++ b/provider/proxmox/proxmox_image.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import (
@@ -8,7 +10,6 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-
 	"os"
 	"strconv"
 	"strings"

--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import (

--- a/provider/proxmox/proxmox_store.go
+++ b/provider/proxmox/proxmox_store.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import (

--- a/provider/proxmox/proxmox_volume.go
+++ b/provider/proxmox/proxmox_volume.go
@@ -1,3 +1,5 @@
+//go:build proxmox || !onlyprovider
+
 package proxmox
 
 import "github.com/nanovms/ops/lepton"

--- a/provider/upcloud/provider_disabled.go
+++ b/provider/upcloud/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !upcloud && onlyprovider
+
+package upcloud
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "upcloud"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/upcloud/upcloud.go
+++ b/provider/upcloud/upcloud.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 //go:generate mockgen -source=$GOFILE -destination=$PWD/mocks/${GOFILE} -package=mocks
 
 package upcloud
@@ -11,7 +13,6 @@ import (
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/service"
-
 	"github.com/nanovms/ops/types"
 )
 

--- a/provider/upcloud/upcloud_image.go
+++ b/provider/upcloud/upcloud_image.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud
 
 import (
@@ -5,11 +7,10 @@ import (
 	"math"
 	"os"
 
-	"github.com/nanovms/ops/types"
-
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
 	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/types"
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/provider/upcloud/upcloud_image_test.go
+++ b/provider/upcloud/upcloud_image_test.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud_test
 
 import (

--- a/provider/upcloud/upcloud_instance.go
+++ b/provider/upcloud/upcloud_instance.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud
 
 import (

--- a/provider/upcloud/upcloud_instance_test.go
+++ b/provider/upcloud/upcloud_instance_test.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud_test
 
 import (

--- a/provider/upcloud/upcloud_store.go
+++ b/provider/upcloud/upcloud_store.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud
 
 import (

--- a/provider/upcloud/upcloud_test.go
+++ b/provider/upcloud/upcloud_test.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud_test
 
 import (

--- a/provider/upcloud/upcloud_volume.go
+++ b/provider/upcloud/upcloud_volume.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud
 
 import (

--- a/provider/upcloud/upcloud_volume_test.go
+++ b/provider/upcloud/upcloud_volume_test.go
@@ -1,3 +1,5 @@
+//go:build upcloud || !onlyprovider
+
 package upcloud_test
 
 import (

--- a/provider/vbox/provider_disabled.go
+++ b/provider/vbox/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !vbox && onlyprovider
+
+package vbox
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "vbox"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/vbox/vbox.go
+++ b/provider/vbox/vbox.go
@@ -1,3 +1,5 @@
+//go:build vbox || !onlyprovider
+
 package vbox
 
 import "github.com/nanovms/ops/types"

--- a/provider/vbox/vbox_image.go
+++ b/provider/vbox/vbox_image.go
@@ -1,3 +1,5 @@
+//go:build vbox || !onlyprovider
+
 package vbox
 
 import (
@@ -8,10 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/types"
 	"github.com/nanovms/ops/wsl"
-
-	"github.com/nanovms/ops/lepton"
 	"github.com/olekukonko/tablewriter"
 )
 

--- a/provider/vbox/vbox_instance.go
+++ b/provider/vbox/vbox_instance.go
@@ -1,3 +1,5 @@
+//go:build vbox || !onlyprovider
+
 package vbox
 
 import (

--- a/provider/vbox/vbox_volume.go
+++ b/provider/vbox/vbox_volume.go
@@ -1,3 +1,5 @@
+//go:build vbox || !onlyprovider
+
 package vbox
 
 import (

--- a/provider/vsphere/provider_disabled.go
+++ b/provider/vsphere/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !vsphere && onlyprovider
+
+package vsphere
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "vsphere"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/vsphere/vsphere.go
+++ b/provider/vsphere/vsphere.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vsphere/vsphere_image.go
+++ b/provider/vsphere/vsphere_image.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vsphere/vsphere_instance.go
+++ b/provider/vsphere/vsphere_instance.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vsphere/vsphere_store.go
+++ b/provider/vsphere/vsphere_store.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vsphere/vsphere_test.go
+++ b/provider/vsphere/vsphere_test.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vsphere/vsphere_volume.go
+++ b/provider/vsphere/vsphere_volume.go
@@ -1,3 +1,5 @@
+//go:build vsphere || !onlyprovider
+
 package vsphere
 
 import (

--- a/provider/vultr/provider_disabled.go
+++ b/provider/vultr/provider_disabled.go
@@ -1,0 +1,15 @@
+//go:build !vultr && onlyprovider
+
+package vultr
+
+import (
+	"github.com/nanovms/ops/provider/disabled"
+)
+
+// ProviderName ...
+const ProviderName = "vultr"
+
+// NewProvider ...
+func NewProvider() *disabled.Provider {
+	return disabled.NewProvider(ProviderName)
+}

--- a/provider/vultr/vultr.go
+++ b/provider/vultr/vultr.go
@@ -1,3 +1,5 @@
+//go:build vultr || !onlyprovider
+
 package vultr
 
 import (

--- a/provider/vultr/vultr_image.go
+++ b/provider/vultr/vultr_image.go
@@ -1,3 +1,5 @@
+//go:build vultr || !onlyprovider
+
 package vultr
 
 import (

--- a/provider/vultr/vultr_instance.go
+++ b/provider/vultr/vultr_instance.go
@@ -1,3 +1,5 @@
+//go:build vultr || !onlyprovider
+
 package vultr
 
 import (

--- a/provider/vultr/vultr_store.go
+++ b/provider/vultr/vultr_store.go
@@ -1,3 +1,5 @@
+//go:build vultr || !onlyprovider
+
 package vultr
 
 import (

--- a/provider/vultr/vultr_volume.go
+++ b/provider/vultr/vultr_volume.go
@@ -1,3 +1,5 @@
+//go:build vultr || !onlyprovider
+
 package vultr
 
 import "github.com/nanovms/ops/lepton"


### PR DESCRIPTION
the final implementation is like https://github.com/nanovms/ops/pull/1445#issuecomment-1493407963

---

By default nothing changes and all providers are compiled and available.

However now we have build tags to disable each provider (except `onprem`). i.e: the following command builds only `onprem` and all other providers are disabled.
```sh
go build -tags 
noaws,noazure,nodigitalocean,nogcp,nohyperv,noibm,nolinode,nooci,noopenshift,noopenstack,noproxmox,noupcloud,novbox,novsphere,novultr
```
---
available tags:
- no**aws**
- no**azure**
- no**digitalocean**
- no**gcp**
- no**hyperv**
- no**ibm**
- no**linode**
- no**oci**
- no**openshift**
- no**openstack**
- no**proxmox**
- no**upcloud**
- no**vbox**
- no**vsphere**
- no**vultr**
