### PR TITLE
AWS createSnapshot(): fix setting of snapshot volume size

### DIFF
--- a/provider/aws/aws_image.go
+++ b/provider/aws/aws_image.go
@@ -242,14 +242,19 @@ func (p *AWS) createSnapshot(imagePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	snapshotSize := fi.Size()
+	sizeInGb := snapshotSize / (1024 * 1024 * 1024)
+	if sizeInGb*1024*1024*1024 < snapshotSize {
+		sizeInGb++
+	}
 
 	// maxBar include process of createSnapshot, completeSnapshot, putSnapshot (include request and response from ebs api)
-	maxBar := (fi.Size()/int64(SnapshotBlockDataLength))*2 + 2
+	maxBar := (snapshotSize/int64(SnapshotBlockDataLength))*2 + 2
 	bar := progressbar.Default(maxBar)
 
 	snapshotOutput, err := p.volumeService.StartSnapshot(&ebs.StartSnapshotInput{
 		Tags:       []*ebs.Tag{},
-		VolumeSize: aws.Int64(1),
+		VolumeSize: aws.Int64(sizeInGb),
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
When creating a snapshot for an AWS image, the size of the snapshot volume is currently hardcoded to 1 GB; instead, it should reflect the actual size of the image being created, otherwise creation of images larger than 1 GB fails with error "Block index NNNN is beyond the volume size extent".