### PR TITLE
vSphere instance create: check for existence of image

### DIFF
--- a/provider/vsphere/vsphere_instance.go
+++ b/provider/vsphere/vsphere_instance.go
@@ -5,6 +5,7 @@ package vsphere
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,6 +68,11 @@ func (v *Vsphere) CreateInstance(ctx *lepton.Context) error {
 	}
 
 	dpath := ds.Path(imgName + "/" + imgName + "2.vmdk")
+	_, err = ds.Stat(context.TODO(), dpath)
+	if err != nil {
+		log.Debug(err)
+		return errors.New("Image " + imgName + " not found")
+	}
 	disk := devices.CreateDisk(dcontroller, ds.Reference(), dpath)
 
 	disk = devices.ChildDisk(disk)


### PR DESCRIPTION
With the VMWare vSphere provider, if an `ops instance create` command is issued with an invalid image name, the CreateVM() function fails with an "Invalid configuration for device '1'" error message, from which it's difficult to infer the root cause of the problem. This change adds a call to Stat() on the datastore in order to check that the image file from which an the instance disk is being created exists, and report that the image name is invalid if the file is not found.
return appropriate error when image not found