### PR TITLE
Image creation: add support for images without a bootloader

### DIFF
--- a/cmd/flags_nightly.go
+++ b/cmd/flags_nightly.go
@@ -56,12 +56,13 @@ func PersistNightlyCommandFlags(cmdFlags *pflag.FlagSet) {
 func updateNanosToolsPaths(c *types.Config, version string) {
 	if c.NightlyBuild {
 		version = "nightly"
-		c.Kernel = path.Join(api.GetOpsHome(), version, "kernel.img")
-		c.Boot = path.Join(api.GetOpsHome(), version, "boot.img")
 	}
 
 	if c.Boot == "" {
-		c.Boot = path.Join(api.GetOpsHome(), version, "boot.img")
+		bootPath := path.Join(api.GetOpsHome(), version, "boot.img")
+		if _, err := os.Stat(bootPath); err == nil {
+			c.Boot = bootPath
+		}
 	}
 
 	c.UefiBoot = api.GetUefiBoot(version)
@@ -74,8 +75,10 @@ func updateNanosToolsPaths(c *types.Config, version string) {
 		log.Fatalf("error: %v: %v\n", c.Kernel, err)
 	}
 
-	if _, err := os.Stat(c.Boot); os.IsNotExist(err) {
-		log.Fatalf("error: %v: %v\n", c.Boot, err)
+	if c.Boot != "" {
+		if _, err := os.Stat(c.Boot); os.IsNotExist(err) {
+			log.Fatalf("error: boot file '%v' not found\n", c.Boot)
+		}
 	}
 
 	if len(c.NameServers) == 0 {

--- a/cmd/flags_nightly_test.go
+++ b/cmd/flags_nightly_test.go
@@ -28,7 +28,6 @@ func TestCreateNightlyFlags(t *testing.T) {
 func TestNightlyFlagsMergeToConfig(t *testing.T) {
 
 	nightlyPath := path.Join(lepton.GetOpsHome(), "nightly")
-	currentOpsPath := path.Join(lepton.GetOpsHome(), lepton.LocalReleaseVersion)
 
 	t.Run("if nighly flag is enabled should set boot and kernel nightly paths ", func(t *testing.T) {
 		flagSet := pflag.NewFlagSet("test", 0)
@@ -44,34 +43,6 @@ func TestNightlyFlagsMergeToConfig(t *testing.T) {
 			Boot:         path.Join(nightlyPath, "boot.img"),
 			UefiBoot:     path.Join(nightlyPath, "bootx64.efi"),
 			Kernel:       path.Join(nightlyPath, "/kernel.img"),
-			CloudConfig:  types.ProviderConfig{},
-			RunConfig:    types.RunConfig{},
-			NameServers:  []string{"8.8.8.8"},
-			NightlyBuild: true,
-		}
-
-		nightlyFlags.MergeToConfig(c)
-
-		assert.Equal(t, expected, c)
-	})
-
-	t.Run("if nighly flag is enabled should override current configuration boot and kernel paths with nightly paths", func(t *testing.T) {
-		flagSet := pflag.NewFlagSet("test", 0)
-
-		cmd.PersistNightlyCommandFlags(flagSet)
-
-		flagSet.Set("nightly", "true")
-
-		nightlyFlags := cmd.NewNightlyCommandFlags(flagSet)
-
-		c := &types.Config{
-			Kernel: currentOpsPath + "/kernel.img",
-			Boot:   currentOpsPath + "/boot.img",
-		}
-		expected := &types.Config{
-			Boot:         nightlyPath + "/boot.img",
-			UefiBoot:     path.Join(nightlyPath, "bootx64.efi"),
-			Kernel:       nightlyPath + "/kernel.img",
 			CloudConfig:  types.ProviderConfig{},
 			RunConfig:    types.RunConfig{},
 			NameServers:  []string{"8.8.8.8"},

--- a/fs/mkfs_test.go
+++ b/fs/mkfs_test.go
@@ -14,7 +14,7 @@ func CheckMKFSSize(t *testing.T, mkfs *MkfsCommand, s string, size int64) {
 }
 
 func TestMKFSCommand(t *testing.T) {
-	mkfs := NewMkfsCommand(nil)
+	mkfs := NewMkfsCommand(nil, false)
 
 	t.Run("filesystem size", func(t *testing.T) {
 		err := mkfs.SetFileSystemSize("size")

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -459,7 +459,7 @@ func createImageFile(c *types.Config, m *fs.Manifest) error {
 		fmt.Printf("Manifest:\n\t%+v\n", m)
 	}
 
-	mkfsCommand := fs.NewMkfsCommand(m)
+	mkfsCommand := fs.NewMkfsCommand(m, true)
 
 	if c.BaseVolumeSz != "" {
 		mkfsCommand.SetFileSystemSize(c.BaseVolumeSz)

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -85,9 +85,9 @@ func CreateLocalVolume(config *types.Config, name, data, provider string) (Nanos
 			return vol, err
 		}
 
-		mkfsCommand = fs.NewMkfsCommand(m)
+		mkfsCommand = fs.NewMkfsCommand(m, false)
 	} else {
-		mkfsCommand = fs.NewMkfsCommand(nil)
+		mkfsCommand = fs.NewMkfsCommand(nil, false)
 	}
 
 	mkfsCommand.SetLabel(name)


### PR DESCRIPTION
With this change, if the `Boot` attribute in the configuration is empty, Ops does not require a boot.img file: if such file is found, it is inserted in the image being created, otherwise Ops builds internally a partition table when creating the image. This allows crating images without a legacy bootloader (e.g. images with a UEFI bootloader, or images with no bootloader at all, which can be used when the kernel binary file is passed directly to the hypervisor).
As part of these changes, if the user specifies in the configuration a kernel and/or boot file path, these settings are no longer overridden by the nightly flag.