### PR TITLE
Update aws_image.go

### DIFF
--- a/provider/aws/aws_image.go
+++ b/provider/aws/aws_image.go
@@ -416,6 +416,7 @@ var (
 		"c6g":  true,
 		"c6gd": true,
 		"c6gn": true,
+		"c6i":  true,
 		"d3":   true,
 		"d3en": true,
 		"g4dn": true,


### PR DESCRIPTION
note that c6i is nitro based per docs here:
https://aws.amazon.com/ec2/instance-types/c6i/