### PR TITLE
add json options to vultr

### DIFF
--- a/provider/vultr/vultr_image.go
+++ b/provider/vultr/vultr_image.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -111,6 +112,9 @@ func (v *Vultr) ListImages(ctx *lepton.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+	if ctx.Config().RunConfig.JSON {
+		return json.NewEncoder(os.Stdout).Encode(snaps)
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)

--- a/provider/vultr/vultr_instance.go
+++ b/provider/vultr/vultr_instance.go
@@ -4,6 +4,7 @@ package vultr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -96,6 +97,9 @@ func (v *Vultr) ListInstances(ctx *lepton.Context) error {
 	}
 
 	log.Debug("instances:", instances)
+	if ctx.Config().RunConfig.JSON {
+		return json.NewEncoder(os.Stdout).Encode(instances)
+	}
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"ID", "Plan", "MainIP", "Status", "ImageID", "Region"})


### PR DESCRIPTION
this copies the same layout as the Digitalocean provider. You previously discussed moving the JSON setting around.

Couldn't get this to build locally because the go mirror seems to be misbehaving around docker/distribution V2.8.0. Contemplated upgrading to v2.8.1 in the PR but maybe not.