### PR TITLE
Proxmox instance: add serial port device

### DIFF
--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -190,6 +190,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	data.Set("memory", p.memory)
 	data.Set("onboot", p.onboot)
 	data.Set("protection", p.protection)
+	data.Set("serial0", "socket")
 
 	// Configuring network interfaces
 


### PR DESCRIPTION
This allows using the xterm.js console tool from the Proxmox web interface to see the output messages printed by an instance. xterm.js is a terminal emulator that captures the serial port logs output by an instance, and is not affected if the instance resets itself, thus allowing users to see e.g. crash messages if an instance reboot is triggered by a crash.
The alternative tool for seeing instance output via the Proxmox web interface is noVNC, which captures the logs sent to the VGA device; this tool is still available, and can be used independently from xterm.js.