### PR TITLE
log(qemu): restore qemu command verbose log

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -94,8 +94,10 @@ func (q *qemu) Command(rconfig *types.RunConfig) *exec.Cmd {
 	if q.atExitHook != "" {
 		qc := qemuBaseCommand() + " " + strings.Join(args, " ")
 		fullCmd := qc + "; " + q.atExitHook
+		logv(rconfig, fullCmd)
 		q.cmd = exec.Command("/bin/sh", "-c", fullCmd)
 	} else {
+		logv(rconfig, qemuBaseCommand()+" "+strings.Join(args, " "))
 		q.cmd = exec.Command(qemuBaseCommand(), args...)
 	}
 


### PR DESCRIPTION
it was removed at https://github.com/nanovms/ops/pull/1489
If it was not intended, this pr restores it, otherwise ignore and close it.