### PR TITLE
tfs: support new tag types

### DIFF
--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -19,6 +19,7 @@ type BuildImageCommandFlags struct {
 	DisableArgsCopy bool
 	CmdEnvs         []string
 	ImageName       string
+	TFSv4           bool
 	Mounts          []string
 	TargetRoot      string
 	IPAddress       string
@@ -53,6 +54,10 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 
 	if flags.ImageName != "" {
 		c.RunConfig.ImageName = flags.ImageName
+	}
+
+	if flags.TFSv4 {
+		c.TFSv4 = true
 	}
 
 	setNanosBaseImage(c)
@@ -146,6 +151,11 @@ func NewBuildImageCommandFlags(cmdFlags *pflag.FlagSet) (flags *BuildImageComman
 		exitWithError(err.Error())
 	}
 
+	flags.TFSv4, err = cmdFlags.GetBool("tfsv4")
+	if err != nil {
+		exitWithError(err.Error())
+	}
+
 	flags.TargetRoot, err = cmdFlags.GetString("target-root")
 	if err != nil {
 		exitWithError(err.Error())
@@ -209,6 +219,7 @@ func PersistBuildImageCommandFlags(cmdFlags *pflag.FlagSet) {
 	cmdFlags.StringArrayP("envs", "e", nil, "env arguments")
 	cmdFlags.StringP("target-root", "r", "", "target root")
 	cmdFlags.StringP("imagename", "i", "", "image name")
+	cmdFlags.BoolP("tfsv4", "4", false, "use TFSv4")
 	cmdFlags.StringArray("mounts", nil, "mount <volume_id:mount_path>")
 	cmdFlags.StringArrayP("args", "a", nil, "command line arguments")
 	cmdFlags.BoolP("disable-args-copy", "", false, "disable copying of files passed as arguments")

--- a/cmd/flags_pkg_test.go
+++ b/cmd/flags_pkg_test.go
@@ -108,6 +108,7 @@ func TestPkgFlagsMergeToConfig(t *testing.T) {
 		RunConfig: types.RunConfig{
 			Memory: "2G",
 		},
+		TFSv4: true,
 	}
 
 	err = pkgFlags.MergeToConfig(c)
@@ -137,6 +138,7 @@ func TestPkgFlagsMergeToConfig(t *testing.T) {
 			Memory:    "2G",
 			ImageName: lepton.GetOpsHome() + "/images/ops",
 		},
+		TFSv4: true,
 	}
 
 	assert.Equal(t, expectedConfig, c)

--- a/fs/mkfs.go
+++ b/fs/mkfs.go
@@ -130,14 +130,15 @@ var uefiFileBootaa64 = []byte{
 
 // MkfsCommand wraps mkfs calls
 type MkfsCommand struct {
-	bootPath   string
-	uefiPath   string
-	label      string
-	manifest   *Manifest
-	partitions bool
-	size       int64
-	outPath    string
-	rootTfs    *tfs
+	bootPath    string
+	uefiPath    string
+	label       string
+	manifest    *Manifest
+	partitions  bool
+	size        int64
+	outPath     string
+	rootTfs     *tfs
+	oldEncoding bool
 }
 
 // NewMkfsCommand returns an instance of MkfsCommand
@@ -210,6 +211,11 @@ func (m *MkfsCommand) SetLabel(label string) {
 	m.label = label
 }
 
+// SetOldEncoding forces use of TFS version 4
+func (m *MkfsCommand) SetOldEncoding() {
+	m.oldEncoding = true
+}
+
 // Execute runs mkfs command
 func (m *MkfsCommand) Execute() error {
 	if m.outPath == "" {
@@ -269,7 +275,7 @@ func (m *MkfsCommand) Execute() error {
 	if manifest != nil {
 		manifest.finalize()
 		if manifest.boot != nil {
-			_, err = tfsWrite(outFile, outOffset, bootFSSize, "", manifest.boot)
+			_, err = tfsWrite(outFile, outOffset, bootFSSize, "", manifest.boot, m.oldEncoding)
 			if err != nil {
 				return fmt.Errorf("cannot write boot filesystem: %v", err)
 			}
@@ -279,7 +285,7 @@ func (m *MkfsCommand) Execute() error {
 	} else {
 		root = mkFS()
 	}
-	m.rootTfs, err = tfsWrite(outFile, outOffset, 0, m.label, root)
+	m.rootTfs, err = tfsWrite(outFile, outOffset, 0, m.label, root, m.oldEncoding)
 	if err != nil {
 		return fmt.Errorf("cannot write root filesystem: %v", err)
 	}

--- a/fs/tfs_test.go
+++ b/fs/tfs_test.go
@@ -10,7 +10,7 @@ func TestLogExt(t *testing.T) {
 		size:      512,
 	}
 	t.Run("initial log ext", func(t *testing.T) {
-		ext := tfs.newLogExt(true)
+		ext := tfs.newLogExt(true, false)
 		if string(ext.buffer[:6]) != "NVMTFS" {
 			t.Errorf("invalid TFS magic: got %d want 'NVMTFS'", ext.buffer[:6])
 		}

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -501,6 +501,10 @@ func createImageFile(c *types.Config, m *fs.Manifest) error {
 
 	mkfsCommand.SetFileSystemPath(c.RunConfig.ImageName)
 
+	if c.TFSv4 {
+		mkfsCommand.SetOldEncoding()
+	}
+
 	err = mkfsCommand.Execute()
 	if err != nil {
 		return err

--- a/lepton/volume.go
+++ b/lepton/volume.go
@@ -99,6 +99,10 @@ func CreateLocalVolume(config *types.Config, name, data, provider string) (Nanos
 		mkfsCommand.SetFileSystemSize(config.BaseVolumeSz)
 	}
 
+	if config.TFSv4 {
+		mkfsCommand.SetOldEncoding()
+	}
+
 	err := mkfsCommand.Execute()
 	if err != nil {
 		return vol, errors.Wrap(err, 1)

--- a/types/config.go
+++ b/types/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	// TargetRoot
 	TargetRoot string `json:",omitempty"`
 
+	// TFSv4 forces use of the deprecated TFS version 4 encoding
+	TFSv4 bool `json:",omitempty"`
+
 	// Version
 	Version string `json:",omitempty"`
 


### PR DESCRIPTION
This change adds support for vector, immediate integer and string types within the tfs implementation, advancing tfsVersion to 5. This should only be merged once TFS v5 support has been merged into Nanos and released.

See https://github.com/nanovms/nanos/pull/1903