### PR TITLE
lepton: fix dropped error

### DIFF
--- a/lepton/image.go
+++ b/lepton/image.go
@@ -175,6 +175,9 @@ func addFilesFromPackage(packagepath string, m *fs.Manifest, ppath string) {
 		} else {
 			err = m.AddFile(e.Name(), rootPath+"/"+e.Name())
 		}
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 }


### PR DESCRIPTION
This picks up a dropped `err` variable in the `lepton` package.