### PR TITLE
On-prem instances: add support for VGA-compatible GPUs

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -184,7 +184,7 @@ func (q *qemu) addVfioPci(pciClass string, count int) error {
 			}
 		} else if detectedAddress != "" && strings.Contains(line, "driver") && strings.Contains(line, "vfio-pci") {
 			q.devices = append(q.devices, device{
-				driver:  "vfio-pci",
+				driver:  "vfio-pci,rombar=0",
 				devtype: "host",
 				devid:   detectedAddress,
 			})
@@ -438,9 +438,8 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) error {
 			if runtime.GOOS != "linux" {
 				return fmt.Errorf("GPU passthrough is only supported on Linux")
 			}
-			// Enable passthrough on PCI devices with class 03 (display) and
-			// subclass 02 (3D controller).
-			if err := q.addVfioPci("0302", rconfig.GPUs); err != nil {
+			// Enable passthrough on PCI devices with class 03 (display).
+			if err := q.addVfioPci("03", rconfig.GPUs); err != nil {
 				return fmt.Errorf("Error setting up PCI GPU passthrough: %v", err)
 			}
 		} else {


### PR DESCRIPTION
Some GPU devices (e.g. NVIDIA GeForce RTX 3090 and 4090) are VGA-compatible, thus their PCI subclass is 0x00; the existing Ops code is assuming that all GPUs have PCI subclass 0x02 (3D controller), which prevents setting up passthrough of VGA-compatible GPUs. This change removes the check for the PCI subclass when enumerating PCI devices, so that passthrough can be configured for all available GPUs.
In addition, the `rombar=0` option is being added to the Qemu command line, so that any PCI option ROM present in a GPU is not exposed to the VM; this fixes 2 problems:
- execution of the GPU ROM by the BIOS appears to lock up the VM (at least with Qemu version 6.2.0) when the GPU is the only VGA-compatible device in the VM
- configuration of a GPU in VGA text mode by the BIOS causes the VGA console driver in the Nanos kernel to bind to the GPU device, thereby preventing the Nvidia GPU klib from binding to the GPU