### PR TITLE
gcp(tags): backward compatible extended usage

### DIFF
--- a/provider/gcp/gcp.go
+++ b/provider/gcp/gcp.go
@@ -35,14 +35,21 @@ type GCloudOperation struct {
 	operationType string
 }
 
-func buildGcpTags(tags []types.Tag) map[string]string {
-	labels := map[string]string{}
+func buildGcpLabels(tags []types.Tag, imageORinstance string) map[string]string {
+	labels := map[string]string{"createdby": "ops"}
 	for _, tag := range tags {
+		switch imageORinstance {
+		case "instance":
+			if !tag.IsInstanceLabel() {
+				continue
+			}
+		case "image":
+			if !tag.IsImageLabel() {
+				continue
+			}
+		}
 		labels[tag.Key] = tag.Value
 	}
-
-	labels["createdby"] = "ops"
-
 	return labels
 }
 

--- a/provider/gcp/gcp_image.go
+++ b/provider/gcp/gcp_image.go
@@ -103,7 +103,7 @@ func (p *GCloud) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	rb := &compute.Image{
 		Name:         c.CloudConfig.ImageName,
-		Labels:       buildGcpTags(ctx.Config().CloudConfig.Tags),
+		Labels:       buildGcpLabels(ctx.Config().CloudConfig.Tags, "image"),
 		Architecture: "X86_64",
 		RawDisk: &compute.ImageRawDisk{
 			Source: sourceURL,

--- a/provider/gcp/gcp_instance_group.go
+++ b/provider/gcp/gcp_instance_group.go
@@ -53,7 +53,7 @@ func (p *GCloud) createInstanceTemplate(ctx *lepton.Context, instanceGroup strin
 					},
 				},
 			},
-			Labels: buildGcpTags(ctx.Config().CloudConfig.Tags),
+			Labels: buildGcpLabels(ctx.Config().CloudConfig.Tags, "instance"),
 			Tags: &compute.Tags{
 				Items: []string{instanceName},
 			},

--- a/types/config.go
+++ b/types/config.go
@@ -208,6 +208,61 @@ type Tag struct {
 
 	// Value
 	Value string `json:"value"`
+
+	// Attribute extended
+	Attribute *TagAttribute `json:"attribute,omitempty"`
+}
+
+// TagAttribute ...
+type TagAttribute struct {
+	// Image Label Tag
+	ImageLabel *bool `json:"image_label,omitempty"`
+
+	// Instance Label Tag
+	InstanceLabel *bool `json:"instance_label,omitempty"`
+
+	// Instance Network Tag - will use the Value
+	InstanceNetwork *bool `json:"instance_network,omitempty"`
+
+	// Instance Metadata Tag
+	InstanceMetadata *bool `json:"instance_metadata,omitempty"`
+}
+
+// HasAttribute checks if extended attributes are being used
+func (t Tag) HasAttribute() bool {
+	return !(t.Attribute == nil || reflect.ValueOf(*t.Attribute).IsZero())
+}
+
+// IsImageLabel ...
+func (t Tag) IsImageLabel() bool {
+	if !t.HasAttribute() {
+		return true // backward compatibility
+	}
+	return t.Attribute.ImageLabel != nil && *t.Attribute.ImageLabel
+}
+
+// IsInstanceLabel ...
+func (t Tag) IsInstanceLabel() bool {
+	if !t.HasAttribute() {
+		return true // backward compatibility
+	}
+	return t.Attribute.InstanceLabel != nil && *t.Attribute.InstanceLabel
+}
+
+// IsInstanceNetwork ...
+func (t Tag) IsInstanceNetwork() bool {
+	if !t.HasAttribute() {
+		return false
+	}
+	return t.Attribute.InstanceNetwork != nil && *t.Attribute.InstanceNetwork
+}
+
+// IsInstanceMetadata ...
+func (t Tag) IsInstanceMetadata() bool {
+	if !t.HasAttribute() {
+		return false
+	}
+	return t.Attribute.InstanceMetadata != nil && *t.Attribute.InstanceMetadata
 }
 
 // RunConfig provides runtime details


### PR DESCRIPTION
I need a bit more control over what goes where.
The existing behavior is kept the same, unless one uses the new specific definitions.

- this config behaves the same as before:
```json
{
  "CloudConfig": {
    "Tags": [
      {
        "key": "instance-and-image",
        "value": "instance-image"
      }
    ]
  }
}
```
- new config options - all options (you can set to `true` only what you need)
```json
{
  "CloudConfig": {
    "Tags": [
      {
        "key": "everywhere",
        "value": "image-instance-metadata-valueAtnetwork",
        "image_label": true, // added to image labels upon image build
        "instance_label": true, // added to instance labels upon instance creation
        "instance_metadata": true // added to instance custom metadata upon instance creation
        "instance_network": true,  // tag VALUE is added to instance network tags
      }
    ]
  }
}
```
