### PR TITLE
gcp(volumes): configurable autoattach upon instance creation

### DIFF
--- a/types/config.go
+++ b/types/config.go
@@ -333,6 +333,9 @@ type RunConfig struct {
 	// Mounts
 	Mounts []string `json:",omitempty"`
 
+	// AttachVolumeOnInstanceCreate tries to attach the volumes configured in Mounts upon instance creation
+	AttachVolumeOnInstanceCreate bool `json:",omitempty"`
+
 	// NetMask
 	NetMask string `json:",omitempty"`
 


### PR DESCRIPTION
- `RunConfig.AttachVolumeOnInstanceCreate` - will attempt to attach already created disk(s)/volume(s) to the instance that is being created with `ops instance create --config config.json ....`

```json
{
  "Mounts": {
    "volume_name_or_id": "/db"
  },
  "RunConfig": {
    "AttachVolumeOnInstanceCreate": true
  }
}
```

**Note**: this feature is available on **ops config file only**