### PR TITLE
Minor pkg command changes

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -457,7 +457,7 @@ func cmdFromPackage(cmd *cobra.Command, args []string) {
 	}
 
 	version, _ := flags.GetString("version")
-	if newpkg == "" {
+	if version == "" {
 		fmt.Println("missing new version")
 		os.Exit(1)
 	}
@@ -485,7 +485,7 @@ func cmdFromRun(cmd *cobra.Command, args []string) {
 	}
 
 	version, _ := flags.GetString("version")
-	if newpkg == "" {
+	if version == "" {
 		fmt.Println("missing new version")
 		os.Exit(1)
 	}

--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -114,7 +114,7 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 
 	sysroot := tempDirectory + "/sysroot"
 
-	copyFromContainer(cli, containerInfo.ID, targetExecutablePath, tempDirectory+"/program")
+	copyFromContainer(cli, containerInfo.ID, targetExecutablePath, tempDirectory+"/"+targetExecutable)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -158,8 +158,8 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 		version = "latest"
 	}
 	c := &types.Config{
-		Program: packageName + "/program",
-		Args:    []string{"/program"},
+		Program: packageName + "/" + targetExecutable,
+		Args:    []string{"/" + targetExecutable},
 		Version: version,
 	}
 

--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -114,7 +114,10 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 
 	sysroot := tempDirectory + "/sysroot"
 
-	copyFromContainer(cli, containerInfo.ID, targetExecutablePath, tempDirectory+"/"+targetExecutable)
+	nameMatches := regexp.MustCompile(`(.*\/)?(.*)$`).FindStringSubmatch(targetExecutable)
+	targetExecutableName := nameMatches[2]
+	
+	copyFromContainer(cli, containerInfo.ID, targetExecutablePath, tempDirectory+"/"+targetExecutableName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -158,8 +161,8 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 		version = "latest"
 	}
 	c := &types.Config{
-		Program: packageName + "/" + targetExecutable,
-		Args:    []string{"/" + targetExecutable},
+		Program: packageName + "/" + targetExecutableName,
+		Args:    []string{"/" + targetExecutableName},
 		Version: version,
 	}
 

--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -33,7 +33,7 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 			log.Fatal(err)
 		}
 		// just in case the version is blank
-		packageName = strings.TrimRight(name+"-"+version, "-")
+		packageName = strings.TrimRight(name+"_"+version, "_")
 	}
 
 	script := fmt.Sprintf(`{

--- a/cmd/flags_config.go
+++ b/cmd/flags_config.go
@@ -50,7 +50,7 @@ func (flags *ConfigCommandFlags) MergeToConfig(c *types.Config) (err error) {
 func unWarpConfig(file string, c *types.Config) (err error) {
 	data, err := os.ReadFile(file)
 	if err != nil {
-		log.Fatalf("error reading config: %v\nIf you are trying to use interoplation in your\nconfig's JSON set 'ops_render_config=true' in your ENV", err)
+		log.Fatalf("error reading config: %v\nIf you are trying to use interpolation in your\nconfig's JSON set 'ops_render_config=true' in your ENV", err)
 	}
 	if os.Getenv("ops_render_config") == "true" {
 		loadedEnvJSON := os.ExpandEnv(string(data))


### PR DESCRIPTION
Made a few changes to `pkg` to address some things I came across while learning to use it recently.

- `pkg from-run` and `pkg from-pkg` were supposed to require the `-v` version flag to append to the package name, but the wrong variable was checked
- changed `pkg from-docker` to not append the version using a different format to `from-run` and `from-pkg`
- Made `pkg from-docker` copy over the Program using the executable's actual name instead of just "program". Loading a package by default saves an image using the name of its executable. This resulted in the image being shown with the name “program” under `ops image list`, which as someone new to OPS was very confusing and led me astray regarding an unrelated problem I was having. It also means the images from different local packages overwrite each other. I didn’t know about the `--imagename` flag for `ops pkg load` at the time, but I think the default should be to use the original executable’s name as defined with e.g. the `--file` flag of `ops pkg from-docker`

Another change I wanted to make was to make `ops pkg from-docker` with the `--copy` flag copy over symlink files (the links themselves, not what they point to) into the package's sysroot. This was because the Python Docker image I was using tried and failed to use the version compatibility link `libz.so.1` (among others) despite the linked to file, `libz.so.1.2.11`, being present in the sysroot, resulting in a crash. I figured it’d be in the spirit of “copying the whole file system” (as --copy is described) for something like a Python package to just work off the bat. I thought the change would be fairly trivial, but was mistaken; couldn't get it to work in a reasonable amount of time. Keen to hear thoughts on this