### PR TITLE
Onprem volumes: add support for virtual ID mounts

### DIFF
--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -116,7 +116,7 @@ func ExtractFromDockerImage(imageName string, packageName string, targetExecutab
 
 	nameMatches := regexp.MustCompile(`(.*\/)?(.*)$`).FindStringSubmatch(targetExecutable)
 	targetExecutableName := nameMatches[2]
-	
+
 	copyFromContainer(cli, containerInfo.ID, targetExecutablePath, tempDirectory+"/"+targetExecutableName)
 	if err != nil {
 		log.Fatal(err)

--- a/provider/onprem/onprem_volume.go
+++ b/provider/onprem/onprem_volume.go
@@ -97,10 +97,15 @@ func (op *OnPrem) AttachVolume(ctx *lepton.Context, instanceName string, volumeN
 
 	last := instance.Mgmt
 
+	deviceAddCmd := `{ "execute": "device_add", "arguments": {"driver": "scsi-hd", "bus": "scsi0.0", "drive": "` + volumeName + `", "id": "` + volumeName + `"`
+	if attachID >= 0 {
+		deviceAddCmd += fmt.Sprintf(`, "device_id": "persistent-disk-%d"`, attachID)
+	}
+	deviceAddCmd += `}}`
 	commands := []string{
 		`{ "execute": "qmp_capabilities" }`,
 		`{ "execute": "blockdev-add", "arguments": {"driver": "raw", "node-name":"` + volumeName + `", "file": {"driver": "file", "filename": "` + vol + `"} } }`,
-		`{ "execute": "device_add", "arguments": {"driver": "scsi-hd", "bus": "scsi0.0", "drive": "` + volumeName + `", "id": "` + volumeName + `"}}`,
+		deviceAddCmd,
 	}
 
 	c, err := net.Dial("tcp", "localhost:"+last)


### PR DESCRIPTION
With this change, it is possible to specify a virtual ID in a mount directive for on-prem images, and then hot-plug a volume on a running instance by using the virtual ID in the `ops volume attach` command.
Example configuration:
```
  "Mounts": {
    "%1": "/data1",
    "%2": "/data2"
  },
  "RunConfig": {
    "QMP": true
  }
```
After creating an image with `ops image create` and then an instance with `ops instance create`, a volume can be mounted in the "data1" directory with `ops volume attach myInstance %1:myVolume`, or in the "data2" directory with `ops volume attach myInstance %2:myVolume`.

It is still possible to not specify a virtual ID in the volume attach command, in which case the volume can only be mounted by using a mount directive that contains the volume identifier (UUID or label).