### PR TITLE
gcp(volumes): ops volume create-image/create-from (GCP only)

### DIFF
--- a/lepton/provider.go
+++ b/lepton/provider.go
@@ -67,6 +67,9 @@ type Storage interface {
 
 // VolumeService is an interface for volume related operations
 type VolumeService interface {
+	CreateVolumeImage(ctx *Context, imageName, data, provider string) error
+	CreateVolumeFromImage(ctx *Context, imageName, volumeName, provider string) error
+
 	CreateVolume(ctx *Context, volumeName, data, provider string) (NanosVolume, error)
 	GetAllVolumes(ctx *Context) (*[]NanosVolume, error)
 	DeleteVolume(ctx *Context, volumeName string) error

--- a/provider/aws/aws_volume.go
+++ b/provider/aws/aws_volume.go
@@ -264,3 +264,13 @@ func (a *AWS) findVolumeByName(name string) (*ec2.Volume, error) {
 
 	return nil, fmt.Errorf("volume '%s' not found", name)
 }
+
+// CreateVolumeImage ...
+func (a *AWS) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (a *AWS) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/azure/azure_volume.go
+++ b/provider/azure/azure_volume.go
@@ -4,6 +4,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -237,4 +238,14 @@ func (a *Azure) getDisksClient() (*compute.DisksClient, error) {
 	vmClient.Authorizer = authr
 	vmClient.AddToUserAgent(userAgent)
 	return &vmClient, nil
+}
+
+// CreateVolumeImage ...
+func (a *Azure) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (a *Azure) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/digitalocean/digital_ocean_volume.go
+++ b/provider/digitalocean/digital_ocean_volume.go
@@ -2,7 +2,11 @@
 
 package digitalocean
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (do *DigitalOcean) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (do *DigitalOcean) AttachVolume(ctx *lepton.Context, image, name string, at
 // DetachVolume is a stub to satisfy VolumeService interface
 func (do *DigitalOcean) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (do *DigitalOcean) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (do *DigitalOcean) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/disabled/provider_disabled.go
+++ b/provider/disabled/provider_disabled.go
@@ -138,3 +138,13 @@ func (p *Provider) AttachVolume(ctx *lepton.Context, instanceName, volumeName st
 func (p *Provider) DetachVolume(ctx *lepton.Context, instanceName, volumeName string) error {
 	return nil
 }
+
+// CreateVolumeImage ...
+func (p *Provider) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return nil
+}
+
+// CreateVolumeFromImage ...
+func (p *Provider) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return nil
+}

--- a/provider/hyperv/hyperv.go
+++ b/provider/hyperv/hyperv.go
@@ -65,3 +65,13 @@ func (p *Provider) AttachVolume(ctx *lepton.Context, image, name string, attachI
 func (p *Provider) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return errors.New("Unsupported")
 }
+
+// CreateVolumeImage ...
+func (p *Provider) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (p *Provider) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/ibm/ibm_volume.go
+++ b/provider/ibm/ibm_volume.go
@@ -2,7 +2,11 @@
 
 package ibm
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (v *IBM) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (v *IBM) AttachVolume(ctx *lepton.Context, image, name string, attachID int
 // DetachVolume is a stub to satisfy VolumeService interface
 func (v *IBM) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (v *IBM) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (v *IBM) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/linode/linode_volume.go
+++ b/provider/linode/linode_volume.go
@@ -2,7 +2,11 @@
 
 package linode
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (v *Linode) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (v *Linode) AttachVolume(ctx *lepton.Context, image, name string, attachID 
 // DetachVolume is a stub to satisfy VolumeService interface
 func (v *Linode) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (v *Linode) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (v *Linode) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/oci/oci_volume.go
+++ b/provider/oci/oci_volume.go
@@ -127,3 +127,13 @@ func (p *Provider) DetachVolume(ctx *lepton.Context, image, name string) (err er
 
 	return
 }
+
+// CreateVolumeImage ...
+func (p *Provider) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (p *Provider) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/onprem/onprem_volume.go
+++ b/provider/onprem/onprem_volume.go
@@ -1,6 +1,7 @@
 package onprem
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -319,4 +320,14 @@ func AddMountsFromConfig(config *types.Config) error {
 	}
 
 	return nil
+}
+
+// CreateVolumeImage ...
+func (op *OnPrem) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (op *OnPrem) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/openshift/provider.go
+++ b/provider/openshift/provider.go
@@ -3,6 +3,7 @@
 package openshift
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -154,4 +155,14 @@ func (oc *OpenShift) AttachVolume(ctx *lepton.Context, instanceName, volumeName 
 // DetachVolume detaches a volume from a nano instance
 func (oc *OpenShift) DetachVolume(ctx *lepton.Context, instanceName, volumeName string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (oc *OpenShift) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (oc *OpenShift) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/openstack/openstack_volume.go
+++ b/provider/openstack/openstack_volume.go
@@ -250,3 +250,13 @@ func (o *OpenStack) DetachVolume(ctx *lepton.Context, image, name string) error 
 
 	return fmt.Errorf("volume %v is not attached to instance %v", name, image)
 }
+
+// CreateVolumeImage ...
+func (o *OpenStack) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (o *OpenStack) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/proxmox/proxmox_volume.go
+++ b/provider/proxmox/proxmox_volume.go
@@ -2,7 +2,11 @@
 
 package proxmox
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (p *ProxMox) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (p *ProxMox) AttachVolume(ctx *lepton.Context, image, name string, attachID
 // DetachVolume is a stub to satisfy VolumeService interface
 func (p *ProxMox) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (p *ProxMox) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (p *ProxMox) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/relayered/relayered_volume.go
+++ b/provider/relayered/relayered_volume.go
@@ -2,7 +2,11 @@
 
 package relayered
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (v *Relayered) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (v *Relayered) AttachVolume(ctx *lepton.Context, image, name string, attach
 // DetachVolume is a stub to satisfy VolumeService interface
 func (v *Relayered) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (v *Relayered) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (v *Relayered) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/upcloud/upcloud_volume.go
+++ b/provider/upcloud/upcloud_volume.go
@@ -206,3 +206,13 @@ func (p *Provider) getVolumeByName(ctx *lepton.Context, volumeName string) (volu
 
 	return
 }
+
+// CreateVolumeImage ...
+func (p *Provider) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (p *Provider) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/vbox/vbox_volume.go
+++ b/provider/vbox/vbox_volume.go
@@ -49,3 +49,13 @@ func (p *Provider) DetachVolume(ctx *lepton.Context, image, name string) (err er
 
 	return
 }
+
+// CreateVolumeImage ...
+func (p *Provider) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (p *Provider) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
+}

--- a/provider/vsphere/vsphere_volume.go
+++ b/provider/vsphere/vsphere_volume.go
@@ -4,6 +4,7 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -290,4 +291,14 @@ func (v *Vsphere) getVirtualMachine(instanceName string) (*object.VirtualMachine
 	}
 
 	return object.NewVirtualMachine(v.client, vms[0].Reference()), nil
+}
+
+// CreateVolumeImage ...
+func (v *Vsphere) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (v *Vsphere) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }

--- a/provider/vultr/vultr_volume.go
+++ b/provider/vultr/vultr_volume.go
@@ -2,7 +2,11 @@
 
 package vultr
 
-import "github.com/nanovms/ops/lepton"
+import (
+	"errors"
+
+	"github.com/nanovms/ops/lepton"
+)
 
 // CreateVolume is a stub to satisfy VolumeService interface
 func (v *Vultr) CreateVolume(ctx *lepton.Context, name, data, provider string) (lepton.NanosVolume, error) {
@@ -28,4 +32,14 @@ func (v *Vultr) AttachVolume(ctx *lepton.Context, image, name string, attachID i
 // DetachVolume is a stub to satisfy VolumeService interface
 func (v *Vultr) DetachVolume(ctx *lepton.Context, image, name string) error {
 	return nil
+}
+
+// CreateVolumeImage ...
+func (v *Vultr) CreateVolumeImage(ctx *lepton.Context, imageName, data, provider string) error {
+	return errors.New("Unsupported")
+}
+
+// CreateVolumeFromImage ...
+func (v *Vultr) CreateVolumeFromImage(ctx *lepton.Context, imageName, volumeName, provider string) error {
+	return errors.New("Unsupported")
 }


### PR DESCRIPTION
---

- **ops volume create-image**
```
$ ops volume create-image --help
create volume image only

Usage:
  ops volume create-image <image_name> [flags]

Flags:
  -d, --data string   volume image data source
  -h, --help          help for create-image
  -s, --size string   volume image size when restored onto a persistent disk
```

---

- **ops volume create-from**

```
$ ops volume create-from --help 
create volume from existing image

Usage:
  ops volume create-from <image_name> <volume_name> [flags]

Flags:
  -h, --help          help for create-from
  -s, --size string   volume image size when restored onto a persistent disk
```

---

**Note**: Don't like the api very much, but at the same time didn't want to touch the existing commands. Needed this so drafting it here for feedback (or in case someone else needs it). 