### PR TITLE
GCP: add confidential VM support (AMD SEV)

### DIFF
--- a/provider/gcp/gcp_image.go
+++ b/provider/gcp/gcp_image.go
@@ -105,20 +105,23 @@ func (p *GCloud) CreateImage(ctx *lepton.Context, imagePath string) error {
 		Name:         c.CloudConfig.ImageName,
 		Labels:       buildGcpLabels(ctx.Config().CloudConfig.Tags, "image"),
 		Architecture: "X86_64",
+		GuestOsFeatures: []*compute.GuestOsFeature{
+			{
+				Type: "GVNIC",
+			},
+		},
 		RawDisk: &compute.ImageRawDisk{
 			Source: sourceURL,
 		},
 	}
 
+	if c.Uefi {
+		rb.GuestOsFeatures = append(rb.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "UEFI_COMPATIBLE",
+		})
+	}
 	if strings.HasPrefix(c.CloudConfig.Flavor, "t2a") {
 		rb.Architecture = "ARM64"
-
-		gof := &compute.GuestOsFeature{
-			Type: "GVNIC",
-		}
-		l := []*compute.GuestOsFeature{}
-		l = append(l, gof)
-		rb.GuestOsFeatures = l
 	}
 
 	op, err := p.Service.Images.Insert(c.CloudConfig.ProjectID, rb).Context(context).Do()

--- a/provider/gcp/gcp_image.go
+++ b/provider/gcp/gcp_image.go
@@ -28,6 +28,10 @@ func amendConfig(c *types.Config) {
 
 		c.Kernel = strings.Replace(c.Kernel, "/kernel.img", "-arm/kernel.img", -1)
 	}
+	if c.CloudConfig.ConfidentialVM {
+		/* Confidential VM feature can only be enabled with UEFI-compatible images */
+		c.Uefi = true
+	}
 }
 
 // BuildImage to be upload on GCP
@@ -122,6 +126,10 @@ func (p *GCloud) CreateImage(ctx *lepton.Context, imagePath string) error {
 	}
 	if strings.HasPrefix(c.CloudConfig.Flavor, "t2a") {
 		rb.Architecture = "ARM64"
+	} else {
+		rb.GuestOsFeatures = append(rb.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: "SEV_CAPABLE",
+		})
 	}
 
 	op, err := p.Service.Images.Insert(c.CloudConfig.ProjectID, rb).Context(context).Do()

--- a/provider/gcp/gcp_instance.go
+++ b/provider/gcp/gcp_instance.go
@@ -166,6 +166,15 @@ func (p *GCloud) CreateInstance(ctx *lepton.Context) error {
 		}
 	}
 
+	if c.CloudConfig.ConfidentialVM {
+		rb.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
+			EnableConfidentialCompute: true,
+		}
+		rb.Scheduling = &compute.Scheduling{
+			// Confidential Instance Config is only supported when OnHostMaintenance is set to TERMINATE
+			OnHostMaintenance: "TERMINATE",
+		}
+	}
 	if c.CloudConfig.Spot {
 		rb.Scheduling = &compute.Scheduling{
 			ProvisioningModel: "SPOT",

--- a/types/config.go
+++ b/types/config.go
@@ -140,6 +140,9 @@ type ProviderConfig struct {
 	// BucketNamespace is required on uploading files to cloud providers as oci
 	BucketNamespace string `json:",omitempty"`
 
+	// Enable confidential computing
+	ConfidentialVM bool `json:",omitempty"`
+
 	// DedicatedHostID
 	DedicatedHostID string `json:",omitempty"`
 


### PR DESCRIPTION
This changeset adds a new boolean configuration option "ConfidentialVM" which, when set to true, will enable confidential computing on cloud providers that support this feature. It also adds support for this feature in Google Cloud Platform, where AMD-equipped instances can run with the Confidential VM service, which uses AMD Secure Encrypted Virtualization.