### PR TITLE
gcp(instance): manage simultaneous multithreading (SMT)

### DIFF
--- a/provider/gcp/gcp_instance.go
+++ b/provider/gcp/gcp_instance.go
@@ -95,6 +95,9 @@ func (p *GCloud) CreateInstance(ctx *lepton.Context) error {
 		Tags: &compute.Tags{
 			Items: []string{instanceName},
 		},
+		AdvancedMachineFeatures: &compute.AdvancedMachineFeatures{
+			ThreadsPerCore: c.RunConfig.ThreadsPerCore,
+		},
 	}
 
 	// Handle tags based on configured property

--- a/types/config.go
+++ b/types/config.go
@@ -380,6 +380,12 @@ type RunConfig struct {
 
 	// VolumeSizeInGb is an optional parameter only available for OpenStack.
 	VolumeSizeInGb int `json:",omitempty"`
+
+	// ThreadsPerCore: The number of threads per physical core. To disable
+	// simultaneous multithreading (SMT) set this to 1. If unset, the
+	// maximum number of threads supported per core by the underlying
+	// processor is assumed.
+	ThreadsPerCore int64 `json:",omitempty"`
 }
 
 // Nic describes a nic


### PR DESCRIPTION
- **ThreadsPerCore**: The number of threads per physical core. To disable
  simultaneous multithreading (SMT) set this to 1. If unset, the
  maximum number of threads supported per core by the underlying
  processor is assumed.

```json
 { 
  "RunConfig": {
    "ThreadsPerCore": 1
  }
}
```