### PR TITLE
On-prem instances: fix reboot command

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -553,8 +553,6 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) error {
 		q.addSerial("stdio")
 	}
 
-	q.addFlag("-no-reboot")
-
 	if OPSD != "" || MACPKGD != "" {
 		q.addOption("-L", "/Applications/qemu.app/Contents/MacOS/")
 	}


### PR DESCRIPTION
The existing code is adding the `--no-reboot` flag to the Qemu command line when starting an on-prem instance; this flag was needed in the past when the Nanos kernel during shutdown was issuing a CPU reset via port 0x64 of the PS/2 controller, so that this reset would shut down the VM instead of resetting it. The current kernel no longer issues such CPU reset when running under Qemu: instead, it either performs an ACPI shutdown, or signals an exit code (when the `debug_exit` manifest option is present); thus, the `--no-reboot` flag is no longer needed.
The `--no-reboot` flag causes Qemu to shut down a VM (instead of resetting it) in response to the "system_reset" QMP command (which is executed when a reboot of an on-prem instance is requested); this change fixes the reboot functionality for on-prem instances by removing the `--no-reboot` flag.