### PR TITLE
Commands: add `image env` to list environment variables in image

### DIFF
--- a/cmd/cmd_image.go
+++ b/cmd/cmd_image.go
@@ -22,7 +22,7 @@ func ImageCommands() *cobra.Command {
 	var cmdImage = &cobra.Command{
 		Use:       "image",
 		Short:     "manage nanos images",
-		ValidArgs: []string{"create", "list", "delete", "resize", "sync", "cp", "ls", "tree", "mirror"},
+		ValidArgs: []string{"create", "list", "delete", "resize", "sync", "cp", "ls", "tree", "env", "mirror"},
 		Args:      cobra.OnlyValidArgs,
 	}
 
@@ -37,6 +37,7 @@ func ImageCommands() *cobra.Command {
 	cmdImage.AddCommand(imageCopyCommand())
 	cmdImage.AddCommand(imageLsCommand())
 	cmdImage.AddCommand(imageTreeCommand())
+	cmdImage.AddCommand(imageEnvCommand())
 	cmdImage.AddCommand(imageMirrorCommand())
 
 	return cmdImage
@@ -643,6 +644,29 @@ func getDumpLine(indent int, fileInfo os.FileInfo, color string) string {
 	}
 	line += color + fileInfo.Name() + log.ConsoleColors.Reset()
 	return line
+}
+
+func imageEnvCommand() *cobra.Command {
+	var cmdEnv = &cobra.Command{
+		Use:   "env <image_name>",
+		Short: "list environment variables in image",
+		Run:   imageEnvCommandHandler,
+		Args:  cobra.MinimumNArgs(1),
+	}
+	return cmdEnv
+}
+
+func imageEnvCommandHandler(cmd *cobra.Command, args []string) {
+	reader := getLocalImageReader(cmd.Flags(), args)
+	envVars := reader.ListEnv()
+	reader.Close()
+	if len(envVars) == 0 {
+		fmt.Println("(none)")
+	} else {
+		for name, value := range envVars {
+			fmt.Printf("%s: %s\n", name, value)
+		}
+	}
 }
 
 func getLocalImageReader(flags *pflag.FlagSet, args []string) *fs.Reader {

--- a/fs/reader.go
+++ b/fs/reader.go
@@ -62,6 +62,21 @@ func (r *Reader) CopyFile(src, dest string, dereference bool) error {
 	return err
 }
 
+// ListEnv returns the set of environment variables in the image
+func (r *Reader) ListEnv() map[string]string {
+	t := r.rootFS.getTuple("environment")
+	envVars := make(map[string]string)
+	if t != nil {
+		for name, value := range *t {
+			sValue, sOk := value.(string)
+			if sOk {
+				envVars[name] = sValue
+			}
+		}
+	}
+	return envVars
+}
+
 // Close closes the image file
 func (r *Reader) Close() error {
 	return r.imageFile.Close()

--- a/fs/tfs.go
+++ b/fs/tfs.go
@@ -1165,3 +1165,7 @@ func (t *tfs) lookup(cwd *map[string]interface{}, path string) (*map[string]inte
 	}
 	return tuple, parent, nil
 }
+
+func (t *tfs) getTuple(name string) *map[string]interface{} {
+	return getTuple(t.root, name)
+}


### PR DESCRIPTION
This command outputs the list of environment variables found in a local (on-prem) image.
Example:
```
$ ops image env my-image
IMAGE_NAME: my-image
USER: root
PWD: /
NANOS_VERSION: 0.1.48
```