### PR TITLE
onprem(volumes): ops volume info - get label/uuid from raw file

### DIFF
--- a/fs/mkfs.go
+++ b/fs/mkfs.go
@@ -313,18 +313,7 @@ func (m *MkfsCommand) Execute() error {
 
 // GetUUID returns the uuid of file system built
 func (m *MkfsCommand) GetUUID() string {
-	uuid := m.rootTfs.uuid
-
-	/* UUID format: 00112233-4455-6677-8899-aabbccddeeff */
-	var uuidStr string
-	for i := 0; i < 4; i++ {
-		uuidStr += fmt.Sprintf("%02x", uuid[i])
-	}
-	uuidStr += fmt.Sprintf("-%02x%02x-%02x%02x-%02x%02x-", uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9])
-	for i := 10; i < 16; i++ {
-		uuidStr += fmt.Sprintf("%02x", uuid[i])
-	}
-	return uuidStr
+	return m.rootTfs.getUUID()
 }
 
 func mkFS() map[string]interface{} {

--- a/fs/reader.go
+++ b/fs/reader.go
@@ -77,6 +77,16 @@ func (r *Reader) ListEnv() map[string]string {
 	return envVars
 }
 
+// GetUUID of image file system
+func (r *Reader) GetUUID() string {
+	return r.rootFS.getUUID()
+}
+
+// GetLabel of image file system
+func (r *Reader) GetLabel() string {
+	return r.rootFS.label
+}
+
 // Close closes the image file
 func (r *Reader) Close() error {
 	return r.imageFile.Close()

--- a/fs/tfs.go
+++ b/fs/tfs.go
@@ -762,6 +762,21 @@ func (t *tfs) readDir(path string) ([]os.FileInfo, error) {
 	return entries, nil
 }
 
+func (t *tfs) getUUID() string {
+	uuid := t.uuid
+
+	/* UUID format: 00112233-4455-6677-8899-aabbccddeeff */
+	var uuidStr string
+	for i := 0; i < 4; i++ {
+		uuidStr += fmt.Sprintf("%02x", uuid[i])
+	}
+	uuidStr += fmt.Sprintf("-%02x%02x-%02x%02x-%02x%02x-", uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9])
+	for i := 10; i < 16; i++ {
+		uuidStr += fmt.Sprintf("%02x", uuid[i])
+	}
+	return uuidStr
+}
+
 type tfsDecoder struct {
 	tupleRemain uint
 	dict        map[int]interface{}


### PR DESCRIPTION
- `ops volume info`
```
get label/uuid of file system

Usage:
  ops volume info <volume_file_path> [flags]
```
---
Examples:

- `ops volume info /tmp/snapshot-a1db-01.raw`
```sh
service-a1-db-v:b519fe87-0a33-500a-a33b-ee006bf6f4cb
```
- `ops volume info /tmp/snapshot-a1db-01.raw --json`
```json
{
  "label": "service-a1-db-v",
  "uuid": "b519fe87-0a33-500a-a33b-ee006bf6f4cb"
}
```
---

Useful mostly when exporting volumes from the cloud, and on the export flow naming gets lost/changed,  to mount locally for debug. There are other ways to archive the same, but require some more work.