### PR TITLE
Added CloudConfig tags to DO instance

### DIFF
--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -51,6 +51,17 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		})
 	}
 
+	tags := make([]string, 0, len(config.CloudConfig.Tags)+2)
+	tags = append(tags, opsTag, imageName)
+	for _, t := range config.CloudConfig.Tags {
+		// NOTE: this would allow for tags without : in them
+		if t.Key == "" && t.Value != "" {
+			tags = append(tags, t.Value)
+		} else if t.Key != "" && t.Value != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", t.Key, t.Value))
+		}
+	}
+
 	createReq := &godo.DropletCreateRequest{
 		Name:   instanceName,
 		Size:   flavor,
@@ -58,7 +69,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},
-		Tags:    []string{opsTag, imageName},
+		Tags:    tags,
 		SSHKeys: dropletKeys,
 	}
 


### PR DESCRIPTION
This allows for tags set in `CloudConfig` to also be set on DO instance (see https://github.com/nanovms/ops/issues/1578). I implemented it in a way where the value of tag is used if key is empty. This allows for tags without `:` when desired