### PR TITLE
Use VPC field for DO as VPCUUID

### DIFF
--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -51,8 +51,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		})
 	}
 
-	tags := make([]string, 0, len(config.CloudConfig.Tags)+2)
-	tags = append(tags, opsTag, imageName)
+	tags := []string{opsTag, imageName}
 	for _, t := range config.CloudConfig.Tags {
 		// NOTE: this would allow for tags without : in them
 		if t.Key == "" && t.Value != "" {

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -62,9 +62,9 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 	}
 
 	createReq := &godo.DropletCreateRequest{
-		Name:   instanceName,
-		Size:   flavor,
-		Region: config.CloudConfig.Zone,
+		Name:    instanceName,
+		Size:    flavor,
+		Region:  config.CloudConfig.Zone,
 		VPCUUID: config.CloudConfig.VPC,
 		Image: godo.DropletCreateImage{
 			ID: imageID,

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -51,6 +51,17 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		})
 	}
 
+	tags := make([]string, 0, len(config.CloudConfig.Tags)+2)
+	tags = append(tags, opsTag, imageName)
+	for _, t := range config.CloudConfig.Tags {
+		// NOTE: this would allow for tags without : in them
+		if t.Key == "" && t.Value != "" {
+			tags = append(tags, t.Value)
+		} else if t.Key != "" && t.Value != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", t.Key, t.Value))
+		}
+	}
+
 	createReq := &godo.DropletCreateRequest{
 		Name:   instanceName,
 		Size:   flavor,
@@ -58,7 +69,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},
-		Tags:    []string{opsTag, imageName},
+		Tags:    tags,
 		SSHKeys: dropletKeys,
 	}
 

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -65,6 +65,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		Name:   instanceName,
 		Size:   flavor,
 		Region: config.CloudConfig.Zone,
+		VPCUUID: config.CloudConfig.VPC,
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},


### PR DESCRIPTION
Adding the `VPCUUID` field allows you to set a VPC of the droplet in the config.json. Ideally you could reference it by name instead of UUID but thats a DO limitation. At least this way you can set VPC at instance creation without having to do a snapshot and then adding it to non-default VPC

Note: We would need to mention this in the documentation as its not obvious