### PR TITLE
Set VPC on instance creation using VPC name

### DIFF
--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -61,11 +61,20 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		}
 	}
 
+	vpc, err := do.GetVPC(ctx, config.CloudConfig.VPC)
+	if err != nil {
+		return err
+	}
+	vpcUUID := ""
+	if vpc != nil {
+		vpcUUID = vpc.ID
+	}
+
 	createReq := &godo.DropletCreateRequest{
 		Name:    instanceName,
 		Size:    flavor,
 		Region:  config.CloudConfig.Zone,
-		VPCUUID: config.CloudConfig.VPC,
+		VPCUUID: vpcUUID,
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -51,8 +51,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		})
 	}
 
-	tags := make([]string, 0, len(config.CloudConfig.Tags)+2)
-	tags = append(tags, opsTag, imageName)
+	tags := []string{opsTag, imageName}
 	for _, t := range config.CloudConfig.Tags {
 		// NOTE: this would allow for tags without : in them
 		if t.Key == "" && t.Value != "" {

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -61,7 +61,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		}
 	}
 
-	vpc, err := do.GetVPC(ctx, config.CloudConfig.VPC)
+	vpc, err := do.GetVPC(ctx, config.CloudConfig.Zone, config.CloudConfig.VPC)
 	if err != nil {
 		return err
 	}

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -65,7 +65,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 	// if users set VPC uuid instead of name it avoids lookup
 	vpcUUID := config.CloudConfig.VPC
 	if _, err := uuid.Parse(vpcUUID); err != nil {
-		vpc, err := do.GetVPC(ctx, config.CloudConfig.Zone, vpcUUID)
+		vpc, err := do.GetVPC(ctx, vpcUUID)
 		if err != nil {
 			return err
 		}

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -62,9 +62,9 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 	}
 
 	createReq := &godo.DropletCreateRequest{
-		Name:   instanceName,
-		Size:   flavor,
-		Region: config.CloudConfig.Zone,
+		Name:    instanceName,
+		Size:    flavor,
+		Region:  config.CloudConfig.Zone,
 		VPCUUID: config.CloudConfig.VPC,
 		Image: godo.DropletCreateImage{
 			ID: imageID,

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -51,6 +51,17 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		})
 	}
 
+	tags := make([]string, 0, len(config.CloudConfig.Tags)+2)
+	tags = append(tags, opsTag, imageName)
+	for _, t := range config.CloudConfig.Tags {
+		// NOTE: this would allow for tags without : in them
+		if t.Key == "" && t.Value != "" {
+			tags = append(tags, t.Value)
+		} else if t.Key != "" && t.Value != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", t.Key, t.Value))
+		}
+	}
+
 	createReq := &godo.DropletCreateRequest{
 		Name:   instanceName,
 		Size:   flavor,
@@ -58,7 +69,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},
-		Tags:    []string{opsTag, imageName},
+		Tags:    tags,
 		SSHKeys: dropletKeys,
 	}
 

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -64,26 +64,30 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 
 	// if users set VPC uuid instead of name it avoids lookup
 	vpcUUID := config.CloudConfig.VPC
-	if _, err := uuid.Parse(vpcUUID); err != nil {
-		vpc, err := do.GetVPC(ctx, vpcUUID)
-		if err != nil {
-			return err
-		}
-		if vpc != nil {
-			vpcUUID = vpc.ID
+	if vpcUUID != "" {
+		if _, err := uuid.Parse(vpcUUID); err != nil {
+			vpc, err := do.GetVPC(ctx, vpcUUID)
+			if err != nil {
+				return err
+			}
+			if vpc != nil {
+				vpcUUID = vpc.ID
+			}
 		}
 	}
 
 	createReq := &godo.DropletCreateRequest{
-		Name:    instanceName,
-		Size:    flavor,
-		Region:  config.CloudConfig.Zone,
-		VPCUUID: vpcUUID,
+		Name:   instanceName,
+		Size:   flavor,
+		Region: config.CloudConfig.Zone,
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},
 		Tags:    tags,
 		SSHKeys: dropletKeys,
+	}
+	if vpcUUID != "" {
+		createReq.VPCUUID = vpcUUID
 	}
 
 	_, _, err = do.Client.Droplets.Create(context.TODO(), createReq)

--- a/provider/digitalocean/digital_ocean_instance.go
+++ b/provider/digitalocean/digital_ocean_instance.go
@@ -65,6 +65,7 @@ func (do *DigitalOcean) CreateInstance(ctx *lepton.Context) error {
 		Name:   instanceName,
 		Size:   flavor,
 		Region: config.CloudConfig.Zone,
+		VPCUUID: config.CloudConfig.VPC,
 		Image: godo.DropletCreateImage{
 			ID: imageID,
 		},

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -1,0 +1,56 @@
+//go:build digitalocean || do || !onlyprovider
+
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"github.com/nanovms/ops/lepton"
+)
+
+// ListVpcs - List all VPCs
+func (do *DigitalOcean) GetVPC(ctx *lepton.Context, vpcName string) (*godo.VPC, error) {
+
+	if vpcName == "" {
+		return nil, nil
+	}
+
+	page := 1
+	var vpc *godo.VPC
+
+	// ctx.Logger().Debug("getting all vpcs")
+
+	for {
+		opts := &godo.ListOptions{
+			Page:    page,
+			PerPage: 200, // max allowed by DO
+		}
+
+		vpcs, _, err := do.Client.VPCs.List(context.TODO(), opts)
+		if err != nil {
+			return nil, err
+		}
+		if len(vpcs) == 0 {
+			break
+		}
+
+		for _, v := range vpcs {
+			if v.Name == vpcName {
+				if vpc != nil {
+					ctx.Logger().Debugf("found another vpc %s that matches the criteria %s", v.ID, vpcName)
+				}
+				vpc = v
+			}
+		}
+		page++
+	}
+
+	if vpc == nil {
+		ctx.Logger().Debugf("no vpcs with name %s found", vpcName)
+		return nil, fmt.Errorf("vpc %s not found", vpcName)
+	}
+
+	return vpc, nil
+}

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -11,10 +11,13 @@ import (
 )
 
 // ListVpcs - List all VPCs
-func (do *DigitalOcean) GetVPC(ctx *lepton.Context, vpcName string) (*godo.VPC, error) {
+func (do *DigitalOcean) GetVPC(ctx *lepton.Context, zone, vpcName string) (*godo.VPC, error) {
 
 	if vpcName == "" {
 		return nil, nil
+	} else if zone == "" && vpcName != "" {
+		ctx.Logger().Debugf("zone is required to get vpc")
+		return nil, fmt.Errorf("zone is required to get vpc")
 	}
 
 	page := 1
@@ -37,7 +40,7 @@ func (do *DigitalOcean) GetVPC(ctx *lepton.Context, vpcName string) (*godo.VPC, 
 		}
 
 		for _, v := range vpcs {
-			if v.Name == vpcName {
+			if v.Name == vpcName && v.RegionSlug == zone {
 				if vpc != nil {
 					ctx.Logger().Debugf("found another vpc %s that matches the criteria %s", v.ID, vpcName)
 				}

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nanovms/ops/lepton"
 )
 
-// ListVpcs - List all VPCs
+// GetVPC returns a vpc by vpc name and zone
 func (do *DigitalOcean) GetVPC(ctx *lepton.Context, zone, vpcName string) (*godo.VPC, error) {
 
 	if vpcName == "" {

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -20,8 +20,6 @@ func (do *DigitalOcean) GetVPC(ctx *lepton.Context, vpcName string) (*godo.VPC, 
 	page := 1
 	var vpc *godo.VPC
 
-	// ctx.Logger().Debug("getting all vpcs")
-
 	for {
 		opts := &godo.ListOptions{
 			Page:    page,

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -11,13 +11,10 @@ import (
 )
 
 // GetVPC returns a vpc by vpc name and zone
-func (do *DigitalOcean) GetVPC(ctx *lepton.Context, zone, vpcName string) (*godo.VPC, error) {
+func (do *DigitalOcean) GetVPC(ctx *lepton.Context, vpcName string) (*godo.VPC, error) {
 
 	if vpcName == "" {
 		return nil, nil
-	} else if zone == "" && vpcName != "" {
-		ctx.Logger().Debugf("zone is required to get vpc")
-		return nil, fmt.Errorf("zone is required to get vpc")
 	}
 
 	page := 1
@@ -40,7 +37,7 @@ func (do *DigitalOcean) GetVPC(ctx *lepton.Context, zone, vpcName string) (*godo
 		}
 
 		for _, v := range vpcs {
-			if v.Name == vpcName && v.RegionSlug == zone {
+			if v.Name == vpcName {
 				vpc = v
 				break
 			}

--- a/provider/digitalocean/digital_ocean_network.go
+++ b/provider/digitalocean/digital_ocean_network.go
@@ -41,10 +41,8 @@ func (do *DigitalOcean) GetVPC(ctx *lepton.Context, zone, vpcName string) (*godo
 
 		for _, v := range vpcs {
 			if v.Name == vpcName && v.RegionSlug == zone {
-				if vpc != nil {
-					ctx.Logger().Debugf("found another vpc %s that matches the criteria %s", v.ID, vpcName)
-				}
 				vpc = v
+				break
 			}
 		}
 		page++


### PR DESCRIPTION
Adding the `VPCUUID` field allows you to set a VPC of the droplet in the config.json. This way you can set VPC at instance creation without having to do a snapshot and then adding it to non-default VPC