### PR TITLE
Fix local package regexp for packages with hyphen in name

### DIFF
--- a/lepton/package.go
+++ b/lepton/package.go
@@ -27,7 +27,7 @@ import (
 // PackageSysRootFolderName is the name of package root folder
 const PackageSysRootFolderName = "sysroot"
 
-var packageRegex = regexp.MustCompile(`(?P<packageName>[A-Za-z]+)[_-](?P<version>\S+)`)
+var packageRegex = regexp.MustCompile(`(?P<packageName>[A-Za-z-]+)[_-](?P<version>\S+)`)
 
 // PackageList contains a list of known packages.
 type PackageList struct {


### PR DESCRIPTION
Currently there is a bug where because the regexp is liberal enough to allow either _ or - to delimit the break between name and version, a package with dash will fail.

So for instance, a package like

my-package_1.2.3

Will have a name of "my" and a version of "package_1.2.3".

Not wanting to change this behaviour by simply changing the regex to only accept _ as a delimeter, I have changed the regex to split at the *last* match.

Fixes: https://github.com/nanovms/ops/issues/1594