### PR TITLE
Allow arch to be set in manifest for when pushing packages

### DIFF
--- a/lepton/push.go
+++ b/lepton/push.go
@@ -26,6 +26,7 @@ func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLo
 		"version":     pkg.Version,
 		"namespace":   namespace,
 		"private":     privateStr,
+		"arch":        pkg.Arch,
 	}
 	return newfileUploadRequest(PkghubBaseURL+"/packages/create", params, "package", archiveLocation)
 

--- a/types/config.go
+++ b/types/config.go
@@ -7,6 +7,9 @@ import (
 
 // Config for Build
 type Config struct {
+	// Arch defines the architecture to build the image for.
+	Arch string `json:",omitempty"`
+
 	// Args defines an array of commands to execute when the image is launched.
 	Args []string `json:",omitempty"`
 


### PR DESCRIPTION
So this may require a bit more discussion. This PR basically allows you to set an `Arch` variable in the package.manifest as part of your build process, so you can package for multiple architectures as part of your CI builds.

However, I am not sure the mechanism for picking the architecture for when you are running the packages, and also I get errors with it not being able to find an arm64 kernel: `error: /Users/jc/.ops/0.1.50-arm/kernel.img: stat /Users/jc/.ops/0.1.50-arm/kernel.img: no such file or directory)` when trying to build a derivative image.

Other issue is that for GOARCH you use arm64, and it seems like in ops x86_64 is used so needs to be some switching around there.