### PR TITLE
feat: add CPU Architecture for Package Search & List

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -234,6 +234,7 @@ func cmdListPackages(cmd *cobra.Command, args []string) {
 		row = append(row, pkg.Version)
 		row = append(row, pkg.Language)
 		row = append(row, pkg.Runtime)
+		row = append(row, pkg.Arch)
 		row = append(row, pkg.Description)
 		rows = append(rows, row)
 	}
@@ -304,6 +305,7 @@ func cmdSearchPackages(cmd *cobra.Command, args []string) {
 		row = append(row, pkg.Version)
 		row = append(row, pkg.Language)
 		row = append(row, pkg.Runtime)
+		row = append(row, pkg.Arch)
 		row = append(row, pkg.Description)
 		rows = append(rows, row)
 	}
@@ -730,8 +732,9 @@ func loadCommandHandler(cmd *cobra.Command, args []string) {
 
 func pkgTable(packages []api.Package) *tablewriter.Table {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Namespace", "PackageName", "Version", "Language", "Runtime", "Description"})
+	table.SetHeader([]string{"Namespace", "PackageName", "Version", "Language", "Runtime", "CPU Arch", "Description"})
 	table.SetHeaderColor(
+		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
 		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
 		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},
 		tablewriter.Colors{tablewriter.Bold, tablewriter.FgCyanColor},


### PR DESCRIPTION
Hey,

thanks for great project!
Based on issues that I had in #1604 , I thought it would be good add CPU Arch column so it's more obvious what are those packages. Also there are scenarios that you could have both images locally in different architectures and ability to differentiate them is important.
I also thought that behavior in list should be changed to show all arch by default, and to only filter them if someone adds `--arch`.

Let me know if this PR is acceptable and if would be acceptable to change pkg list behaviour.