### PR TITLE
use --arch for ops pkg push cmd (with sanitisation for amd64)

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -593,8 +593,11 @@ func pushCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	private, _ := flags.GetBool("private")
+	arch, _ := flags.GetString("arch")
 	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
+
 	pkgList, err := api.GetLocalPackageList()
+
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -623,7 +626,7 @@ func pushCommandHandler(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(archiveName)
 
-	req, err := api.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName, private)
+	req, err := api.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName, private, arch)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -595,9 +595,7 @@ func pushCommandHandler(cmd *cobra.Command, args []string) {
 	private, _ := flags.GetBool("private")
 	arch, _ := flags.GetString("arch")
 	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
-
 	pkgList, err := api.GetLocalPackageList()
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -593,7 +593,6 @@ func pushCommandHandler(cmd *cobra.Command, args []string) {
 	}
 
 	private, _ := flags.GetBool("private")
-	arch, _ := flags.GetString("arch")
 	ns, name, version := api.GetNSPkgnameAndVersion(pkgIdentifier)
 	pkgList, err := api.GetLocalPackageList()
 	if err != nil {
@@ -624,7 +623,7 @@ func pushCommandHandler(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(archiveName)
 
-	req, err := api.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName, private, arch)
+	req, err := api.BuildRequestForArchiveUpload(ns, name, foundPkg, archiveName, private, pkgFlags.Parch())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lepton/package.go
+++ b/lepton/package.go
@@ -282,7 +282,8 @@ func GetLocalPackageList() ([]Package, error) {
 
 		localPackages, err := os.ReadDir(localPackagesDir)
 		if err != nil {
-			return nil, err
+			log.Infof("could not find local packages directory for arch: %s\n", arches[i])
+			continue
 		}
 		username := GetLocalUsername()
 		for _, pkg := range localPackages {

--- a/lepton/push.go
+++ b/lepton/push.go
@@ -13,17 +13,22 @@ import (
 )
 
 // BuildRequestForArchiveUpload builds the request to upload a package with the provided metadata
-func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLocation string, private bool) (*http.Request, error) {
+func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLocation string, private bool, arch string) (*http.Request, error) {
 	privateStr := "off"
 	if private {
 		privateStr = "on"
 	}
+	if arch == "amd64" || arch == "" {
+		arch = "x86_64"
+	}
+
 	params := map[string]string{
 		"name":        name,
 		"description": pkg.Description,
 		"language":    pkg.Language,
 		"runtime":     pkg.Runtime,
 		"version":     pkg.Version,
+		"arch":        arch,
 		"namespace":   namespace,
 		"private":     privateStr,
 	}

--- a/lepton/push.go
+++ b/lepton/push.go
@@ -21,7 +21,6 @@ func BuildRequestForArchiveUpload(namespace, name string, pkg Package, archiveLo
 	if arch == "amd64" || arch == "" {
 		arch = "x86_64"
 	}
-
 	params := map[string]string{
 		"name":        name,
 		"description": pkg.Description,


### PR DESCRIPTION
Basically this completes the loop for pushing packages with multiple arches via CLI.

Seeing as the current `--arch` flag accepts either `amd64` (as opposed to `x86_64`) or `arm64`, I'm manually changing this in the request data when it's pushed to the repo. 

Also falls back to `x86_64` if it's blank/unset

Also it slightly changes the behaviour when searching local packages, as previously it was erroring out if one of the existing arches didn't exist yet, so we just log it and continue instead.