### PR TITLE
yanking highmem off for arch as we don't require it anymore

### DIFF
--- a/qemu/qemu_unix.go
+++ b/qemu/qemu_unix.go
@@ -481,11 +481,6 @@ func (q *qemu) setConfig(rconfig *types.RunConfig) error {
 
 		q.addOption("-machine", "gic-version=2")
 
-		// https://github.com/kubernetes/minikube/pull/14291
-		// https://github.com/utmapp/UTM/issues/3946
-
-		q.addOption("-machine", "highmem=off")
-
 		q.addOption("-kernel", rconfig.Kernel)
 
 		q.addOption("-device", "virtio-blk-pci,drive=hd0")


### PR DESCRIPTION
related to https://github.com/nanovms/nanos/pull/2043