### PR TITLE
toggle metrics on by default for compose

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -229,6 +229,7 @@ func (com Compose) spawnProgram(comp ComposePackage, dnsIP string, c *types.Conf
 
 	c.RunConfig.InstanceName = pname
 	c.CloudConfig.ImageName = pname
+	c.RunConfig.QMP = true
 
 	z := p.(*onprem.OnPrem)
 	pid, err := z.CreateInstancePID(ctx)
@@ -313,6 +314,7 @@ func (com Compose) spawnDNS(non string) string {
 	env := map[string]string{"non": non}
 
 	c.Env = env
+	c.RunConfig.QMP = true
 
 	z := p.(*onprem.OnPrem)
 	pid, err := z.CreateInstancePID(ctx)

--- a/provider/onprem/instance.go
+++ b/provider/onprem/instance.go
@@ -17,6 +17,7 @@ type instance struct {
 	Mac       string   `json:"mac"`
 	Pid       string   `json:"pid"`
 	Mgmt      string   `json:"mgmt"`
+	Arch      string   `json:"arch"`
 
 	FreeMemory  int64
 	TotalMemory int64

--- a/provider/onprem/onprem_instance.go
+++ b/provider/onprem/onprem_instance.go
@@ -126,12 +126,18 @@ func (p *OnPrem) createInstance(ctx *lepton.Context) (string, error) {
 
 	instances := path.Join(opshome, "instances")
 
+	arch := "arm64"
+	if qemu.ArchCheck() {
+		arch = "amd64"
+	}
+
 	i := instance{
 		Instance: c.RunConfig.InstanceName,
 		Image:    c.RunConfig.ImageName,
 		Ports:    c.RunConfig.Ports,
 		Pid:      pid,
 		Mgmt:     c.RunConfig.Mgmt,
+		Arch:     arch,
 	}
 
 	if c.RunConfig.Bridged {
@@ -514,7 +520,7 @@ func (p *OnPrem) getInstancesStats(ctx *lepton.Context, rinstances []lepton.Clou
 		last := instance.Mgmt
 
 		devid := "2"
-		if qemu.ArchCheck() {
+		if instance.Arch == "amd64" {
 			devid = "3"
 		}
 


### PR DESCRIPTION
this also stores arch in the instance metadata for onprem