### PR TITLE
allow overriding default azure gallery name

### DIFF
--- a/provider/azure/azure_image.go
+++ b/provider/azure/azure_image.go
@@ -424,6 +424,11 @@ func (a *Azure) createGalleryImage(ctx context.Context, location string, imageNa
 }
 
 func (a *Azure) galleryName() string {
+	galleryName := os.Getenv("AZURE_GALLERY_NAME")
+	if galleryName != "" {
+		return galleryName
+	}
+
 	return "nanos_gallery"
 }
 


### PR DESCRIPTION
since gallery names are globally unique you need a diff. one for other regions.