### PR TITLE
set proper klib dir for arm

### DIFF
--- a/lepton/const.go
+++ b/lepton/const.go
@@ -262,9 +262,8 @@ func getKlibsDir(nightly bool, nanosVersion string, arm bool) string {
 	} else if nanosVersion != "" && nanosVersion != "0.0" {
 		if arm {
 			return getReleaseLocalFolder(nanosVersion) + "-arm/klibs"
-		} else {
-			return getReleaseLocalFolder(nanosVersion) + "/klibs"
 		}
+		return getReleaseLocalFolder(nanosVersion) + "/klibs"
 	}
 
 	return getLastReleaseLocalFolder() + "/klibs"

--- a/lepton/const.go
+++ b/lepton/const.go
@@ -256,11 +256,15 @@ func getLastReleaseLocalFolder() string {
 	return getReleaseLocalFolder(getLatestRelVersion())
 }
 
-func getKlibsDir(nightly bool, nanosVersion string) string {
+func getKlibsDir(nightly bool, nanosVersion string, arm bool) string {
 	if nightly {
 		return NightlyLocalFolder() + "/klibs"
 	} else if nanosVersion != "" && nanosVersion != "0.0" {
-		return getReleaseLocalFolder(nanosVersion) + "/klibs"
+		if arm {
+			return getReleaseLocalFolder(nanosVersion) + "-arm/klibs"
+		} else {
+			return getReleaseLocalFolder(nanosVersion) + "/klibs"
+		}
 	}
 
 	return getLastReleaseLocalFolder() + "/klibs"

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -260,7 +260,11 @@ func setManifestFromConfig(m *fs.Manifest, c *types.Config, ppath string) error 
 	if c.KlibDir != "" {
 		m.SetKlibDir(c.KlibDir)
 	} else {
-		m.SetKlibDir(getKlibsDir(c.NightlyBuild, c.NanosVersion))
+		if strings.Contains(c.Kernel, "arm") {
+			m.SetKlibDir(getKlibsDir(c.NightlyBuild, c.NanosVersion, true))
+		} else {
+			m.SetKlibDir(getKlibsDir(c.NightlyBuild, c.NanosVersion, false))
+		}
 	}
 
 	m.AddKlibs(c.Klibs)

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export VERSION="0.1.42"
+export VERSION="0.1.43"
 plat="$(uname -s | awk '{print tolower($0)}')"
 
 # x86-linux


### PR DESCRIPTION
klib dir was being set erroneously when not using nightly - this now sets it according to whatever kernel is being set