### PR TITLE
add nodiscover flag for containers w/out shells && grab symlinks

### DIFF
--- a/cmd/cmd_pkg.go
+++ b/cmd/cmd_pkg.go
@@ -499,13 +499,14 @@ func fromDockerCommandHandler(cmd *cobra.Command, args []string) {
 	packageName, _ := flags.GetString("name")
 	targetExecutable, _ := flags.GetString("file")
 	copyWholeFS, _ := flags.GetBool("copy")
+	nodiscover, _ := flags.GetBool("nodiscover")
 
 	cmdArgs, err := flags.GetStringArray("args")
 	if err != nil {
 		exitWithError(err.Error())
 	}
 
-	packageName, _ = ExtractFromDockerImage(imageName, packageName, pkgFlags.Parch(), targetExecutable, quiet, verbose, copyWholeFS, cmdArgs)
+	packageName, _ = ExtractFromDockerImage(imageName, packageName, pkgFlags.Parch(), targetExecutable, quiet, verbose, copyWholeFS, nodiscover, cmdArgs)
 	fmt.Println(packageName)
 }
 
@@ -827,6 +828,7 @@ func fromDockerCommand() *cobra.Command {
 	persistentFlags.BoolP("copy", "", false, "copy whole file system")
 	persistentFlags.StringP("name", "", "", "name of the package")
 	persistentFlags.BoolP("local", "l", false, "load local package")
+	persistentFlags.BoolP("nodiscover", "", false, "don't try to discover linked libs")
 
 	return cmdFromDocker
 }

--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -69,7 +69,7 @@ func getCMDExecutable(imageName string) (string, error) {
 }
 
 // ExtractFromDockerImage creates a package by extracting an executable and its shared libraries
-func ExtractFromDockerImage(imageName string, packageName string, parch string, targetExecutable string, quiet bool, verbose bool, copyWholeFS bool, args []string) (string, string) {
+func ExtractFromDockerImage(imageName string, packageName string, parch string, targetExecutable string, quiet bool, verbose bool, copyWholeFS bool, nodiscover bool, args []string) (string, string) {
 	var err error
 	var version string
 	var name string
@@ -164,7 +164,8 @@ func ExtractFromDockerImage(imageName string, packageName string, parch string, 
 	foundld := false
 	fmt.Println(librariesPath)
 
-	/*
+	if !nodiscover {
+
 		for _, libraryLine := range librariesPath {
 			sanitizedLibraryLine := sanitizeLine(libraryLine)
 
@@ -193,10 +194,10 @@ func ExtractFromDockerImage(imageName string, packageName string, parch string, 
 			}
 			err = copyFromContainer(cli, containerInfo.ID, libraryPath, libraryDestination)
 			if err != nil {
-				fmt.Println("shit..")
 				log.Fatal(err)
 			}
-		}*/
+		}
+	}
 
 	// for chainguard, might not have ldd or file and might be static but
 	// still need to cp ld; this could use some more work as there could
@@ -210,15 +211,14 @@ func ExtractFromDockerImage(imageName string, packageName string, parch string, 
 	// if file is not on the image once we cp out the binary we can run
 	// file on it locally to resolve the proper ld
 	// or can just use the combination of '--copy' && '--file'
-	/*	if !foundld {
+	if !foundld && !nodiscover {
 		fmt.Println("no loader found - trying others")
 		ldp := "/lib64/ld-linux-x86-64.so.2"
 		err = copyFromContainer(cli, containerInfo.ID, ldp, sysroot+ldp)
 		if err != nil {
 			log.Fatal(err)
 		}
-	}*/
-	fmt.Println(foundld)
+	}
 
 	// like docker if the user doesn't provide version of the image we consider "latest" as the version
 	if version == "" {

--- a/cmd/extract_from_docker.go
+++ b/cmd/extract_from_docker.go
@@ -162,7 +162,6 @@ func ExtractFromDockerImage(imageName string, packageName string, parch string, 
 	}
 
 	foundld := false
-	fmt.Println(librariesPath)
 
 	if !nodiscover {
 
@@ -489,28 +488,7 @@ func copyWholeContainer(cli *dockerClient.Client, containerID string, hostBaseDi
 			}
 
 		case tar.TypeSymlink:
-			fmt.Printf("found a symlink %s\n", target)
-			/*
-			   f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-
-			   	if err != nil {
-			   		return err
-			   	}
-
-			   	if _, err := io.Copy(f, tr); err != nil {
-			   		return err
-			   	}
-
-			   f.Close()
-			*/
-			//			fmt.Printf("Symlink: %s -> %s\n\n", header.Name, header.Linkname)
-			/*
-				targetPath, err := os.Readlink(target)
-				if err != nil {
-					fmt.Println("Error reading symlink:", err)
-				}
-			*/
-			err = os.Symlink(header.Linkname, target) // target, targetPath) // oldPath, newPath)
+			err = os.Symlink(header.Linkname, target)
 			if err != nil {
 				fmt.Println(err)
 			}


### PR DESCRIPTION
for cases where the loader itself is a symlink we either need a corresponding fix in nanos or special handling in ops