### PR TITLE
Update minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo apt-get update && sudo apt-get install ops
 
 Building from source is easy if you have used Go before.
 
-This program requires GO Version 1.13.x or greater.
+This program requires GO Version 1.25.x or greater.
 
 Installing from source follows these general steps:
 


### PR DESCRIPTION
Got this while trying to build: `go: go.mod requires go >= 1.25.0`