### PR TITLE
openstack: fix dropped errors

### DIFF
--- a/provider/openstack/openstack_dns.go
+++ b/provider/openstack/openstack_dns.go
@@ -65,7 +65,9 @@ func (o *OpenStack) DeleteZoneRecordIfExists(config *types.Config, zoneID string
 		Name: recordName,
 	}
 	allPages, err := recordsets.ListByZone(dnsClient, zoneID, listOpts).AllPages()
-
+	if err != nil {
+		return err
+	}
 	allRecords, err := recordsets.ExtractRecordSets(allPages)
 	if err != nil {
 		return err

--- a/provider/openstack/openstack_instance.go
+++ b/provider/openstack/openstack_instance.go
@@ -83,7 +83,7 @@ func getOpenStackInstances(provider *gophercloud.ProviderClient, opts servers.Li
 		return true, nil
 	})
 
-	return cinstances, nil
+	return cinstances, err
 }
 
 // CreateInstance - Creates instance on OpenStack.
@@ -250,6 +250,9 @@ func (o *OpenStack) ListInstances(ctx *lepton.Context) error {
 func (o *OpenStack) DeleteInstance(ctx *lepton.Context, instancename string) error {
 
 	instances, err := o.GetInstances(ctx)
+	if err != nil {
+		return err
+	}
 
 	client, err := openstack.NewComputeV2(o.provider, gophercloud.EndpointOpts{
 		Region: os.Getenv("OS_REGION_NAME"),
@@ -352,7 +355,9 @@ func (o *OpenStack) findInstance(name string) (volume *servers.Server, err error
 
 		return true, nil
 	})
-
+	if err != nil {
+		return server, err
+	}
 	if server != nil {
 		return server, nil
 	}


### PR DESCRIPTION
This fixes several dropped `err` variables in `provider/openstack`.