### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/cmd/flags_build_image.go
+++ b/cmd/flags_build_image.go
@@ -119,7 +119,7 @@ func (flags *BuildImageCommandFlags) MergeToConfig(c *types.Config) (err error) 
 	}
 
 	if c.ManifestPassthrough == nil {
-		c.ManifestPassthrough = make(map[string]interface{})
+		c.ManifestPassthrough = make(map[string]any)
 	}
 
 	// we only set the netconsole port and ip if the consoles have values

--- a/cmd/flags_build_image_test.go
+++ b/cmd/flags_build_image_test.go
@@ -84,7 +84,7 @@ func TestBuildImageFlagsMergeToConfig(t *testing.T) {
 			Env:                 map[string]string{"test": "1234"},
 			NameServers:         []string{"8.8.8.8"},
 			VolumesDir:          lepton.LocalVolumeDir,
-			ManifestPassthrough: map[string]interface{}{},
+			ManifestPassthrough: map[string]any{},
 		}
 
 		err := buildImageFlags.MergeToConfig(c)
@@ -121,7 +121,7 @@ func TestBuildImageFlagsMergeToConfig(t *testing.T) {
 			RunConfig:           types.RunConfig{},
 			Args:                []string{},
 			NameServers:         []string{"8.8.8.8"},
-			ManifestPassthrough: map[string]interface{}{},
+			ManifestPassthrough: map[string]any{},
 		}
 
 		assert.Equal(t, expected, c)

--- a/cmd/print_json.go
+++ b/cmd/print_json.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func printJSON(obj interface{}) {
+func printJSON(obj any) {
 	json, _ := json.MarshalIndent(obj, "", "  ")
 	fmt.Println(string(json))
 }

--- a/crossbuild/env.go
+++ b/crossbuild/env.go
@@ -309,7 +309,7 @@ func (env *Environment) NewEmptyCommand() *EnvironmentCommand {
 }
 
 // NewCommand creates new command to be executed via SSH.
-func (env *Environment) NewCommand(command string, args ...interface{}) *EnvironmentCommand {
+func (env *Environment) NewCommand(command string, args ...any) *EnvironmentCommand {
 	vmCmd := env.NewEmptyCommand()
 	vmCmd.CommandLines = []string{
 		formatCommand(command, args...),
@@ -318,7 +318,7 @@ func (env *Environment) NewCommand(command string, args ...interface{}) *Environ
 }
 
 // NewCommandf creates new formatted command to be executed via SSH.
-func (env *Environment) NewCommandf(format string, args ...interface{}) *EnvironmentCommand {
+func (env *Environment) NewCommandf(format string, args ...any) *EnvironmentCommand {
 	return env.NewCommand(fmt.Sprintf(format, args...))
 }
 

--- a/crossbuild/env_command.go
+++ b/crossbuild/env_command.go
@@ -52,7 +52,7 @@ func (cmd *EnvironmentCommand) Execute() error {
 }
 
 // Then appends command line to the set of commands.
-func (cmd *EnvironmentCommand) Then(command string, args ...interface{}) *EnvironmentCommand {
+func (cmd *EnvironmentCommand) Then(command string, args ...any) *EnvironmentCommand {
 	cmd.CommandLines = append(cmd.CommandLines, formatCommand(command, args...))
 	return cmd
 }
@@ -85,8 +85,8 @@ func (cmd *EnvironmentCommand) executeCommand(client *ssh.Client, cmdLine string
 }
 
 // Formats command and arguments as a single string.
-func formatCommand(command string, args ...interface{}) string {
-	line := []interface{}{command}
+func formatCommand(command string, args ...any) string {
+	line := []any{command}
 	line = append(line, args...)
 	return fmt.Sprintln(line...)
 }

--- a/fs/manifest.go
+++ b/fs/manifest.go
@@ -24,8 +24,8 @@ type ManifestNetworkConfig struct {
 
 // Manifest represent the filesystem.
 type Manifest struct {
-	root        map[string]interface{} // root fs
-	boot        map[string]interface{} // boot fs
+	root        map[string]any // root fs
+	boot        map[string]any // boot fs
 	targetRoot  string
 	klibHostDir string
 }
@@ -37,7 +37,7 @@ func NewManifest(targetRoot string) *Manifest {
 		targetRoot: targetRoot,
 	}
 	m.root["arguments"] = make([]string, 0)
-	m.root["environment"] = make(map[string]interface{})
+	m.root["environment"] = make(map[string]any)
 	return m
 }
 
@@ -117,15 +117,15 @@ func (m *Manifest) AddMount(label, path string) {
 	dirparts := strings.Split(dir, ":")
 	mkDirPath(m.rootDir(), dirparts[0])
 	if m.root["mounts"] == nil {
-		m.root["mounts"] = make(map[string]interface{})
+		m.root["mounts"] = make(map[string]any)
 	}
-	mounts := m.root["mounts"].(map[string]interface{})
+	mounts := m.root["mounts"].(map[string]any)
 	mounts[label] = path
 }
 
 // AddEnvironmentVariable adds environment variables
 func (m *Manifest) AddEnvironmentVariable(name string, value string) {
-	env := m.root["environment"].(map[string]interface{})
+	env := m.root["environment"].(map[string]any)
 	env[name] = value
 }
 
@@ -252,12 +252,12 @@ func (m *Manifest) AddDirectory(dir string, workDir string, opath string, inside
 			node := m.rootDir()
 			for i := 0; i < len(parts); i++ {
 				if _, ok := node[parts[i]]; !ok {
-					node[parts[i]] = make(map[string]interface{})
+					node[parts[i]] = make(map[string]any)
 				}
 				if reflect.TypeOf(node[parts[i]]).Kind() == reflect.String {
 					return fmt.Errorf("directory %q is conflicting with an existing file", hostpath)
 				}
-				node = node[parts[i]].(map[string]interface{})
+				node = node[parts[i]].(map[string]any)
 			}
 		} else {
 			err = m.AddFile(vmpath, hostpath)
@@ -302,12 +302,12 @@ func (m *Manifest) AddRelativeDirectory(src string) error {
 			node := m.rootDir()
 			for i := 0; i < len(parts); i++ {
 				if _, ok := node[parts[i]]; !ok {
-					node[parts[i]] = make(map[string]interface{})
+					node[parts[i]] = make(map[string]any)
 				}
 				if reflect.TypeOf(node[parts[i]]).Kind() == reflect.String {
 					return fmt.Errorf("directory %q is conflicting with an existing file", hostpath)
 				}
-				node = node[parts[i]].(map[string]interface{})
+				node = node[parts[i]].(map[string]any)
 			}
 		} else {
 			err = m.AddFile(vmpath, hostpath)
@@ -328,7 +328,7 @@ func (m *Manifest) FileExists(filepath string) bool {
 		if _, ok := node[parts[i]]; !ok {
 			return false
 		}
-		node = node[parts[i]].(map[string]interface{})
+		node = node[parts[i]].(map[string]any)
 	}
 	pathtest := node[parts[len(parts)-1]]
 	if pathtest != nil && reflect.TypeOf(pathtest).Kind() == reflect.String {
@@ -344,9 +344,9 @@ func (m *Manifest) AddLink(filepath string, hostpath string) error {
 
 	for i := 0; i < len(parts)-1; i++ {
 		if _, ok := node[parts[i]]; !ok {
-			node[parts[i]] = make(map[string]interface{})
+			node[parts[i]] = make(map[string]any)
 		}
-		node = node[parts[i]].(map[string]interface{})
+		node = node[parts[i]].(map[string]any)
 	}
 
 	pathtest := node[parts[len(parts)-1]]
@@ -381,15 +381,15 @@ func (m *Manifest) AddFile(filepath string, hostpath string) error {
 }
 
 // AddFileTo adds a file to a given directory
-func (m *Manifest) AddFileTo(dir map[string]interface{}, filepath string, hostpath string) error {
+func (m *Manifest) AddFileTo(dir map[string]any, filepath string, hostpath string) error {
 	parts := strings.FieldsFunc(filepath, func(c rune) bool { return c == '/' })
 	node := dir
 
 	for i := 0; i < len(parts)-1; i++ {
 		if _, ok := node[parts[i]]; !ok {
-			node[parts[i]] = make(map[string]interface{})
+			node[parts[i]] = make(map[string]any)
 		}
-		node = node[parts[i]].(map[string]interface{})
+		node = node[parts[i]].(map[string]any)
 	}
 
 	pathtest := node[parts[len(parts)-1]]
@@ -414,18 +414,18 @@ func (m *Manifest) AddFileTo(dir map[string]interface{}, filepath string, hostpa
 }
 
 // AddPassthrough to add key, value directly to manifest
-func (m *Manifest) AddPassthrough(key string, value interface{}) {
+func (m *Manifest) AddPassthrough(key string, value any) {
 	m.root[key] = value
 }
 
 func (m *Manifest) finalize() {
 }
 
-func (m *Manifest) bootDir() map[string]interface{} {
+func (m *Manifest) bootDir() map[string]any {
 	return getRootDir(m.boot)
 }
 
-func (m *Manifest) rootDir() map[string]interface{} {
+func (m *Manifest) rootDir() map[string]any {
 	return getRootDir(m.root)
 }
 
@@ -470,12 +470,12 @@ func LookupFile(targetRoot string, path string) (string, error) {
 	return path, err
 }
 
-func mkDir(parent map[string]interface{}, dir string) map[string]interface{} {
+func mkDir(parent map[string]any, dir string) map[string]any {
 	subDir := parent[dir]
 	if subDir != nil {
-		return subDir.(map[string]interface{})
+		return subDir.(map[string]any)
 	}
-	newDir := make(map[string]interface{})
+	newDir := make(map[string]any)
 	parent[dir] = newDir
 	return newDir
 }
@@ -485,7 +485,7 @@ func (m *Manifest) MkdirPath(path string) {
 	mkDirPath(m.rootDir(), path)
 }
 
-func mkDirPath(parent map[string]interface{}, path string) map[string]interface{} {
+func mkDirPath(parent map[string]any, path string) map[string]any {
 	parts := strings.Split(path, "/")
 	for _, element := range parts {
 		if element != "" {

--- a/fs/manifest_test.go
+++ b/fs/manifest_test.go
@@ -25,6 +25,6 @@ func TestManifestWithArgs(t *testing.T) {
 func TestManifestWithEnv(t *testing.T) {
 	m := NewManifest("")
 	m.AddEnvironmentVariable("var1", "value1")
-	env := m.root["environment"].(map[string]interface{})
+	env := m.root["environment"].(map[string]any)
 	assert.Equal(t, "value1", env["var1"])
 }

--- a/fs/mkfs.go
+++ b/fs/mkfs.go
@@ -269,7 +269,7 @@ func (m *MkfsCommand) Execute() error {
 		}
 	}
 	manifest := m.manifest
-	var root map[string]interface{}
+	var root map[string]any
 	if manifest != nil {
 		manifest.finalize()
 		if manifest.boot != nil {
@@ -314,14 +314,14 @@ func (m *MkfsCommand) GetUUID() string {
 	return m.rootTfs.getUUID()
 }
 
-func mkFS() map[string]interface{} {
-	root := make(map[string]interface{})
-	root["children"] = make(map[string]interface{})
+func mkFS() map[string]any {
+	root := make(map[string]any)
+	root["children"] = make(map[string]any)
 	return root
 }
 
-func getRootDir(root map[string]interface{}) map[string]interface{} {
-	return root["children"].(map[string]interface{})
+func getRootDir(root map[string]any) map[string]any {
+	return root["children"].(map[string]any)
 }
 
 // Creates the EFI System Partition, i.e. a FAT32 filesystem with the UEFI loader file in the EFI/Boot directory.

--- a/fs/tfs.go
+++ b/fs/tfs.go
@@ -60,7 +60,7 @@ type tfs struct {
 	nonSymCount int
 	staging     []byte
 	decoder     tfsDecoder
-	root        *map[string]interface{}
+	root        *map[string]any
 }
 
 func (t *tfs) logInit(oldEncoding bool) error {
@@ -232,7 +232,7 @@ func (t *tfs) readLogExt(offset, size uint64) (uint64, error) {
 	}
 }
 
-func (t *tfs) writeDirEntries(dir map[string]interface{}) error {
+func (t *tfs) writeDirEntries(dir map[string]any) error {
 	var err error
 	t.encodeSymbol("children")
 	t.encodeTupleHeader(len(dir))
@@ -251,7 +251,7 @@ func (t *tfs) writeDirEntries(dir map[string]interface{}) error {
 		} else {
 			t.encodeSymbol(k)
 			t.encodeTupleHeader(1) // for "children" attribute
-			err = t.writeDirEntries(v.(map[string]interface{}))
+			err = t.writeDirEntries(v.(map[string]any))
 		}
 		if err != nil {
 			break
@@ -260,7 +260,7 @@ func (t *tfs) writeDirEntries(dir map[string]interface{}) error {
 	return err
 }
 
-func (t *tfs) encodeValue(value interface{}) error {
+func (t *tfs) encodeValue(value any) error {
 	str, isStr := value.(string)
 	if isStr {
 		strType := byte(typeString)
@@ -273,37 +273,37 @@ func (t *tfs) encodeValue(value interface{}) error {
 	strSlice, isStrSlice := value.([]string)
 	if isStrSlice {
 		if !t.currentExt.oldEncoding {
-			vector := make([]interface{}, len(strSlice))
+			vector := make([]any, len(strSlice))
 			for i, str := range strSlice {
 				vector[i] = str
 			}
 			return t.encodeVector(vector)
 		}
-		tuple := make(map[string]interface{})
+		tuple := make(map[string]any)
 		for i, str := range strSlice {
 			tuple[strconv.Itoa(i)] = str
 		}
 		return t.encodeTuple(tuple)
 	}
-	slice, isSlice := value.([]interface{})
+	slice, isSlice := value.([]any)
 	if isSlice {
 		if !t.currentExt.oldEncoding {
 			return t.encodeVector(slice)
 		}
-		tuple := make(map[string]interface{})
+		tuple := make(map[string]any)
 		for i, val := range slice {
 			tuple[strconv.Itoa(i)] = val
 		}
 		return t.encodeTuple(tuple)
 	}
-	tuple, isTuple := value.(map[string]interface{})
+	tuple, isTuple := value.(map[string]any)
 	if isTuple {
 		return t.encodeTuple(tuple)
 	}
 	return fmt.Errorf("unknown type of value %p", value)
 }
 
-func (t *tfs) encodeMetadata(name string, value interface{}) error {
+func (t *tfs) encodeMetadata(name string, value any) error {
 	t.encodeSymbol(name)
 	err := t.encodeValue(value)
 	return err
@@ -324,7 +324,7 @@ func (t *tfs) encodeTupleHeader(tupleEntries int) {
 	t.nonSymCount++
 }
 
-func (t *tfs) encodeTuple(tuple map[string]interface{}) error {
+func (t *tfs) encodeTuple(tuple map[string]any) error {
 	t.encodeTupleHeader(len(tuple))
 	for k, v := range tuple {
 		err := t.encodeMetadata(k, v)
@@ -340,7 +340,7 @@ func (t *tfs) encodeString(s string, dataType byte) {
 	t.staging = append(t.staging, s...)
 }
 
-func (t *tfs) encodeVector(vector []interface{}) error {
+func (t *tfs) encodeVector(vector []any) error {
 	t.pushHeader(entryImmediate, typeVector, len(vector))
 	t.nonSymCount++
 	for _, value := range vector {
@@ -352,7 +352,7 @@ func (t *tfs) encodeVector(vector []interface{}) error {
 	return nil
 }
 
-func (t *tfs) decodeValue(buffer []byte, offset *uint64, oldEncoding bool) (interface{}, error) {
+func (t *tfs) decodeValue(buffer []byte, offset *uint64, oldEncoding bool) (any, error) {
 	var entry, dataType byte
 	length, err := getHeader(buffer, offset, &entry, &dataType, oldEncoding)
 	if err != nil {
@@ -374,10 +374,10 @@ func (t *tfs) decodeValue(buffer []byte, offset *uint64, oldEncoding bool) (inte
 	}
 }
 
-func (t *tfs) decodeVector(buffer []byte, offset *uint64, entry byte, length uint, oldEncoding bool) (*[]interface{}, error) {
-	var vector *[]interface{}
+func (t *tfs) decodeVector(buffer []byte, offset *uint64, entry byte, length uint, oldEncoding bool) (*[]any, error) {
+	var vector *[]any
 	if entry == entryImmediate {
-		newVector := make([]interface{}, length)
+		newVector := make([]any, length)
 		vector = &newVector
 		t.decoder.dict[len(t.decoder.dict)+1] = vector
 	} else {
@@ -400,10 +400,10 @@ func (t *tfs) decodeVector(buffer []byte, offset *uint64, entry byte, length uin
 	return vector, nil
 }
 
-func (t *tfs) decodeTuple(buffer []byte, offset *uint64, entry byte, length uint, oldEncoding bool) (*map[string]interface{}, error) {
-	var tuple *map[string]interface{}
+func (t *tfs) decodeTuple(buffer []byte, offset *uint64, entry byte, length uint, oldEncoding bool) (*map[string]any, error) {
+	var tuple *map[string]any
 	if entry == entryImmediate {
-		newTuple := make(map[string]interface{})
+		newTuple := make(map[string]any)
 		tuple = &newTuple
 		t.decoder.dict[len(t.decoder.dict)+1] = tuple
 	} else {
@@ -475,26 +475,26 @@ func (t *tfs) decodeInteger(buffer []byte, offset *uint64, entry byte, length ui
 	return strconv.FormatInt(int64(val), 10), nil
 }
 
-func (t *tfs) getDictVector(ref uint) (*[]interface{}, error) {
+func (t *tfs) getDictVector(ref uint) (*[]any, error) {
 	value := t.decoder.dict[int(ref)]
 	if value == nil {
 		return nil, fmt.Errorf("indirect vector %d not found", ref)
 	}
 	var isVector bool
-	vector, isVector := value.(*[]interface{})
+	vector, isVector := value.(*[]any)
 	if !isVector {
 		return nil, fmt.Errorf("invalid indirect vector %d", ref)
 	}
 	return vector, nil
 }
 
-func (t *tfs) getDictTuple(ref uint) (*map[string]interface{}, error) {
+func (t *tfs) getDictTuple(ref uint) (*map[string]any, error) {
 	value := t.decoder.dict[int(ref)]
 	if value == nil {
 		return nil, fmt.Errorf("indirect tuple %d not found", ref)
 	}
 	var isTuple bool
-	tuple, isTuple := value.(*map[string]interface{})
+	tuple, isTuple := value.(*map[string]any)
 	if !isTuple {
 		return nil, fmt.Errorf("invalid indirect tuple %d", ref)
 	}
@@ -514,7 +514,7 @@ func (t *tfs) getDictString(ref uint) (string, error) {
 }
 
 func (t *tfs) writeLink(name string, target string) error {
-	tuple := make(map[string]interface{})
+	tuple := make(map[string]any)
 	tuple["linktarget"] = target
 	return t.encodeMetadata(name, tuple)
 }
@@ -530,9 +530,9 @@ func (t *tfs) writeFile(name string, hostPath string) error {
 	if err != nil {
 		return fmt.Errorf("cannot get size of file %q: %w", hostPath, err)
 	}
-	tuple := make(map[string]interface{})
+	tuple := make(map[string]any)
 	tuple["filelength"] = strconv.FormatInt(info.Size(), 10)
-	extents := make(map[string]interface{})
+	extents := make(map[string]any)
 	if info.Size() > 0 {
 		sectors := uint64((info.Size() + sectorSize - 1) / sectorSize)
 		paddedLen := sectors * sectorSize
@@ -557,7 +557,7 @@ func (t *tfs) writeFile(name string, hostPath string) error {
 				return fmt.Errorf("cannot write image file: %w", err)
 			}
 		}
-		extent := make(map[string]interface{})
+		extent := make(map[string]any)
 		extent["length"] = strconv.FormatUint(sectors, 10)
 		extent["offset"] = strconv.FormatUint(t.allocated/sectorSize, 10)
 		extent["allocated"] = extent["length"]
@@ -650,7 +650,7 @@ func (t *tfs) flush() error {
 	return nil
 }
 
-func (t *tfs) readExtent(p []byte, extent *map[string]interface{}, offset uint64) (int, uint64, error) {
+func (t *tfs) readExtent(p []byte, extent *map[string]any, offset uint64) (int, uint64, error) {
 	extentOffset, err := strconv.ParseUint(getString(extent, "offset"), 10, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("cannot parse extent offset: %w", err)
@@ -689,7 +689,7 @@ func (t *tfs) readLink(path string) (string, error) {
 }
 
 func (t *tfs) fileReader(path string) (io.Reader, error) {
-	var fileTuple *map[string]interface{}
+	var fileTuple *map[string]any
 	currentDir := t.root
 	hopCount := 0
 	for {
@@ -754,7 +754,7 @@ func (t *tfs) readDir(path string) ([]os.FileInfo, error) {
 	for k, v := range *children {
 		if (k != ".") && (k != "..") {
 			entries = append(entries, &tfsFileInfo{
-				tuple:       v.(*map[string]interface{}),
+				tuple:       v.(*map[string]any),
 				parentTuple: dir,
 			})
 		}
@@ -779,12 +779,12 @@ func (t *tfs) getUUID() string {
 
 type tfsDecoder struct {
 	tupleRemain uint
-	dict        map[int]interface{}
+	dict        map[int]any
 }
 
 type tfsFileInfo struct {
-	tuple       *map[string]interface{}
-	parentTuple *map[string]interface{}
+	tuple       *map[string]any
+	parentTuple *map[string]any
 }
 
 func (i *tfsFileInfo) IsDir() bool {
@@ -839,17 +839,17 @@ func (i *tfsFileInfo) Size() int64 {
 	return length
 }
 
-func (i *tfsFileInfo) Sys() interface{} {
+func (i *tfsFileInfo) Sys() any {
 	return i.tuple
 }
 
 type tfsFileReader struct {
 	t             *tfs
 	length        uint64
-	extents       *map[string]interface{}
+	extents       *map[string]any
 	extentOffsets []int
 	curExtIndex   int
-	currentExtent *map[string]interface{}
+	currentExtent *map[string]any
 	offset        uint64
 }
 
@@ -966,7 +966,7 @@ func (r *tfsFileReader) getExtentRange() (uint64, uint64, error) {
 func (r *tfsFileReader) selectExtent(index int) {
 	r.curExtIndex = index
 	ext := (*r.extents)[strconv.Itoa(r.extentOffsets[index]/sectorSize)]
-	r.currentExtent = ext.(*map[string]interface{})
+	r.currentExtent = ext.(*map[string]any)
 }
 
 type tlogExt struct {
@@ -1053,20 +1053,20 @@ func getVarint(buffer []byte, offset *uint64) (uint, error) {
 	return result, nil
 }
 
-func getTuple(parent *map[string]interface{}, child string) *map[string]interface{} {
+func getTuple(parent *map[string]any, child string) *map[string]any {
 	entry := (*parent)[child]
 	if entry == nil {
 		return nil
 	}
 	var isTuple bool
-	tuple, isTuple := entry.(*map[string]interface{})
+	tuple, isTuple := entry.(*map[string]any)
 	if !isTuple {
 		return nil
 	}
 	return tuple
 }
 
-func getString(parent *map[string]interface{}, child string) string {
+func getString(parent *map[string]any, child string) string {
 	value := (*parent)[child]
 	if value == nil {
 		return ""
@@ -1078,7 +1078,7 @@ func getString(parent *map[string]interface{}, child string) string {
 	return str
 }
 
-func getChild(parent *map[string]interface{}, child string) *map[string]interface{} {
+func getChild(parent *map[string]any, child string) *map[string]any {
 	children := getTuple(parent, "children")
 	if children == nil {
 		return nil
@@ -1096,7 +1096,7 @@ func newTfs(imgFile *os.File, imgOffset uint64, fsSize uint64) *tfs {
 }
 
 // tfsWrite writes filesystem metadata and contents to image file
-func tfsWrite(imgFile *os.File, imgOffset uint64, fsSize uint64, label string, root map[string]interface{}, oldEncoding bool) (*tfs, error) {
+func tfsWrite(imgFile *os.File, imgOffset uint64, fsSize uint64, label string, root map[string]any, oldEncoding bool) (*tfs, error) {
 	tfs := newTfs(imgFile, imgOffset, fsSize)
 	tfs.label = label
 	rand.Seed(time.Now().UnixNano())
@@ -1111,7 +1111,7 @@ func tfsWrite(imgFile *os.File, imgOffset uint64, fsSize uint64, label string, r
 	tfs.encodeTupleHeader(len(root))
 	for k, v := range root {
 		if k == "children" {
-			err = tfs.writeDirEntries(v.(map[string]interface{}))
+			err = tfs.writeDirEntries(v.(map[string]any))
 			if err != nil {
 				return nil, err
 			}
@@ -1127,7 +1127,7 @@ func tfsWrite(imgFile *os.File, imgOffset uint64, fsSize uint64, label string, r
 
 func tfsRead(imgFile *os.File, fsOffset, fsSize uint64) (*tfs, error) {
 	tfs := newTfs(imgFile, fsOffset, fsSize)
-	tfs.decoder.dict = make(map[int]interface{})
+	tfs.decoder.dict = make(map[int]any)
 	nextExt, err := tfs.readLogExt(0, sectorSize)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read filesystem at first log extension: %w", err)
@@ -1146,19 +1146,19 @@ func tfsRead(imgFile *os.File, fsOffset, fsSize uint64) (*tfs, error) {
 	return tfs, nil
 }
 
-func fixupDirectory(parent, dir *map[string]interface{}) {
+func fixupDirectory(parent, dir *map[string]any) {
 	children := getTuple(dir, "children")
 	if children == nil {
 		return // not a directory
 	}
 	for _, child := range *children {
-		fixupDirectory(dir, child.(*map[string]interface{}))
+		fixupDirectory(dir, child.(*map[string]any))
 	}
 	(*children)["."] = dir
 	(*children)[".."] = parent
 }
 
-func (t *tfs) lookup(cwd *map[string]interface{}, path string) (*map[string]interface{}, *map[string]interface{}, error) {
+func (t *tfs) lookup(cwd *map[string]any, path string) (*map[string]any, *map[string]any, error) {
 	if strings.HasPrefix(path, "/") {
 		cwd = t.root
 	}
@@ -1181,6 +1181,6 @@ func (t *tfs) lookup(cwd *map[string]interface{}, path string) (*map[string]inte
 	return tuple, parent, nil
 }
 
-func (t *tfs) getTuple(name string) *map[string]interface{} {
+func (t *tfs) getTuple(name string) *map[string]any {
 	return getTuple(t.root, name)
 }

--- a/lepton/helpers.go
+++ b/lepton/helpers.go
@@ -124,7 +124,7 @@ func CustomRelTime(a, b time.Time, albl, blbl string, magnitudes []RelTimeMagnit
 		n = len(magnitudes) - 1
 	}
 	mag := magnitudes[n]
-	args := []interface{}{}
+	args := []any{}
 	escaped := false
 	for _, ch := range mag.Format {
 		if escaped {

--- a/lepton/image.go
+++ b/lepton/image.go
@@ -439,7 +439,7 @@ func BuildManifest(c *types.Config) (*fs.Manifest, error) {
 				NetMask: nics[i].NetMask,
 			})
 		} else {
-			ifaces := make(map[string]interface{})
+			ifaces := make(map[string]any)
 
 			// only set if ip given otherwise assume dhcp
 			ifaces["ipaddr"] = nics[i].IPAddress

--- a/log/logger.go
+++ b/log/logger.go
@@ -41,7 +41,7 @@ func (l *Logger) SetDebug(value bool) {
 }
 
 // Logf writes a formatted message to the specified output
-func (l *Logger) Logf(format string, a ...interface{}) {
+func (l *Logger) Logf(format string, a ...any) {
 	if !strings.HasSuffix(format, "\n") {
 		format = format + "\n"
 	}
@@ -49,39 +49,39 @@ func (l *Logger) Logf(format string, a ...interface{}) {
 }
 
 // Log writes message to the specified output
-func (l *Logger) Log(a ...interface{}) {
+func (l *Logger) Log(a ...any) {
 	fmt.Fprintln(l.output, a...)
 }
 
 // Calls Log with foreground color set
-func (l *Logger) logWithColor(color string, a ...interface{}) {
+func (l *Logger) logWithColor(color string, a ...any) {
 	msg := fmt.Sprintln(a...)
 	l.Log(color + strings.TrimSuffix(msg, "\n") + ConsoleColors.Reset())
 }
 
 // Info checks info level is activated to write the message
-func (l *Logger) Info(a ...interface{}) {
+func (l *Logger) Info(a ...any) {
 	if l.info == true {
 		l.logWithColor(ConsoleColors.Blue(), a...)
 	}
 }
 
 // Infof checks info level is activated to write the formatted message
-func (l *Logger) Infof(format string, a ...interface{}) {
+func (l *Logger) Infof(format string, a ...any) {
 	if l.info == true {
 		l.Logf(ConsoleColors.Blue()+format+ConsoleColors.Reset(), a...)
 	}
 }
 
 // Warn checks warn level is activated to write the message
-func (l *Logger) Warn(a ...interface{}) {
+func (l *Logger) Warn(a ...any) {
 	if l.warn == true {
 		l.logWithColor(ConsoleColors.Yellow(), a...)
 	}
 }
 
 // Warnf checks warn level is activated to write the formatted message
-func (l *Logger) Warnf(format string, a ...interface{}) {
+func (l *Logger) Warnf(format string, a ...any) {
 	if l.warn == true {
 		l.Logf(ConsoleColors.Yellow()+format+ConsoleColors.Reset(), a...)
 	}
@@ -93,19 +93,19 @@ func (l *Logger) Error(err error) {
 }
 
 // Errorf checks error level is activated to write the formatted message
-func (l *Logger) Errorf(format string, a ...interface{}) {
+func (l *Logger) Errorf(format string, a ...any) {
 	l.Logf(ConsoleColors.Red()+format+ConsoleColors.Reset(), a...)
 }
 
 // Debug checks debug level is activated to write the message
-func (l *Logger) Debug(a ...interface{}) {
+func (l *Logger) Debug(a ...any) {
 	if l.debug == true {
 		l.logWithColor(ConsoleColors.Cyan(), a...)
 	}
 }
 
 // Debugf checks debug level is activated to write the message
-func (l *Logger) Debugf(format string, a ...interface{}) {
+func (l *Logger) Debugf(format string, a ...any) {
 	if l.debug == true {
 		l.Logf(ConsoleColors.Cyan()+format+ConsoleColors.Reset(), a...)
 	}

--- a/log/logger_default.go
+++ b/log/logger_default.go
@@ -44,27 +44,27 @@ func InitDefault(output io.Writer, config *types.Config) {
 }
 
 // Info logs info-level message using default logger.
-func Info(a ...interface{}) {
+func Info(a ...any) {
 	defaultLogger.Info(a...)
 }
 
 // Infof logs formatted info-level message using default logger.
-func Infof(format string, a ...interface{}) {
+func Infof(format string, a ...any) {
 	defaultLogger.Infof(format, a...)
 }
 
 // Warn logs warning-level message using default logger.
-func Warn(a ...interface{}) {
+func Warn(a ...any) {
 	defaultLogger.Warn(a...)
 }
 
 // Warnf logs formatted warning-level message using default logger.
-func Warnf(format string, a ...interface{}) {
+func Warnf(format string, a ...any) {
 	defaultLogger.Warnf(format, a...)
 }
 
 // Errorf logs formatted error-level formatted string message using default logger.
-func Errorf(format string, a ...interface{}) {
+func Errorf(format string, a ...any) {
 	defaultLogger.Errorf(format, a...)
 }
 
@@ -74,7 +74,7 @@ func Error(err error) {
 }
 
 // Fatalf logs formatted error-level formatted string message using default logger then calls os.Exit(1).
-func Fatalf(format string, a ...interface{}) {
+func Fatalf(format string, a ...any) {
 	defaultLogger.Errorf(format, a...)
 	os.Exit(1)
 }
@@ -86,7 +86,7 @@ func Fatal(err error) {
 }
 
 // Panicf logs formatted error-level formatted string message using default logger then calls panic().
-func Panicf(format string, a ...interface{}) {
+func Panicf(format string, a ...any) {
 	defaultLogger.Errorf(format, a...)
 	panic(fmt.Sprintf(format+"\n", a...))
 }
@@ -98,11 +98,11 @@ func Panic(err error) {
 }
 
 // Debug logs debug-level message using default logger.
-func Debug(a ...interface{}) {
+func Debug(a ...any) {
 	defaultLogger.Debug(a...)
 }
 
 // Debugf logs formatted debug-level message using default logger.
-func Debugf(format string, a ...interface{}) {
+func Debugf(format string, a ...any) {
 	defaultLogger.Debugf(format, a...)
 }

--- a/provider/gcp/gcp_network.go
+++ b/provider/gcp/gcp_network.go
@@ -226,6 +226,6 @@ func (p *GCloud) buildFirewallRule(protocol string, ports []string, tag string, 
 	return f
 }
 
-func arrayToString(a interface{}, delim string) string {
+func arrayToString(a any, delim string) string {
 	return strings.Trim(strings.Replace(fmt.Sprint(a), " ", delim, -1), "[]")
 }

--- a/provider/hetzner/hetzner_image.go
+++ b/provider/hetzner/hetzner_image.go
@@ -495,7 +495,7 @@ func sanitizeLabelValue(value string) string {
 	return value
 }
 
-func jsonOutput(v interface{}) error {
+func jsonOutput(v any) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(v)

--- a/provider/hetzner/hetzner_test.go
+++ b/provider/hetzner/hetzner_test.go
@@ -24,7 +24,7 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-func jsonResponse(t *testing.T, status int, body interface{}) *http.Response {
+func jsonResponse(t *testing.T, status int, body any) *http.Response {
 	t.Helper()
 	data, err := json.Marshal(body)
 	if err != nil {

--- a/provider/oci/oci_image_test.go
+++ b/provider/oci/oci_image_test.go
@@ -35,7 +35,7 @@ type putObjectMatcher struct {
 	ContentLength *int64 `mandatory:"true" contributesTo:"header" name:"Content-Length"`
 }
 
-func (p *putObjectMatcher) Matches(x interface{}) bool {
+func (p *putObjectMatcher) Matches(x any) bool {
 	want := x.(objectstorage.PutObjectRequest)
 	return *want.BucketName == *p.BucketName && *want.NamespaceName == *p.NamespaceName && *want.ObjectName == *p.ObjectName && *want.ContentLength == *p.ContentLength
 }

--- a/provider/openstack/openstack_instance.go
+++ b/provider/openstack/openstack_instance.go
@@ -52,8 +52,8 @@ func getOpenStackInstances(provider *gophercloud.ProviderClient, opts servers.Li
 				}
 
 				if z != nil {
-					for _, v := range z.([]interface{}) {
-						sz := v.(map[string]interface{})
+					for _, v := range z.([]any) {
+						sz := v.(map[string]any)
 						version := sz["version"].(float64)
 						if version == 4 {
 							ipv4 = sz["addr"].(string)

--- a/types/config.go
+++ b/types/config.go
@@ -90,7 +90,7 @@ type Config struct {
 	NoTrace []string `json:",omitempty"`
 
 	// Straight passthrough of options to manifest
-	ManifestPassthrough map[string]interface{} `json:",omitempty"`
+	ManifestPassthrough map[string]any `json:",omitempty"`
 
 	// Program
 	Program string `json:",omitempty"`
@@ -450,7 +450,7 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		return cJSON, nil
 	}
 
-	cMap := map[string]interface{}{}
+	cMap := map[string]any{}
 	err = json.Unmarshal(cJSON, &cMap)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace `interface{}` with the `any` alias (available since Go 1.18) across the codebase.

Only type literal usages were changed (not interface definitions).