### PR TITLE
allow instance create on proxmox 9.x

### DIFF
--- a/provider/proxmox/proxmox_checks.go
+++ b/provider/proxmox/proxmox_checks.go
@@ -97,7 +97,7 @@ func (p *ProxMox) CheckStorage(storage string, stype string) error {
 
 	var b bytes.Buffer
 
-	edk := errors.New("no any storages is configured")
+	edk := errors.New("no storage is configured")
 	enb := errors.New("storage is disabled: " + storage)
 	ect := errors.New("storage is not active: " + storage)
 	ecs := errors.New("not found storage: " + storage)

--- a/provider/proxmox/proxmox_image.go
+++ b/provider/proxmox/proxmox_image.go
@@ -88,7 +88,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	var fw io.Writer
 
-	err = w.WriteField("content", "iso")
+	err = w.WriteField("content", "import")
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -96,7 +96,7 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	file := mustOpen(fileName)
 
-	fw, err = w.CreateFormFile(fieldName, file.Name()+".iso")
+	fw, err = w.CreateFormFile(fieldName, file.Name()+".raw")
 	if err != nil {
 		fmt.Printf("Error creating writer: %v\n", err)
 		return err
@@ -135,6 +135,8 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 		fmt.Println(err)
 		return err
 	}
+
+	fmt.Println(string(body))
 
 	err = p.CheckResultType(body, "createimage", p.isoStorageName)
 	if err != nil {

--- a/provider/proxmox/proxmox_image.go
+++ b/provider/proxmox/proxmox_image.go
@@ -60,7 +60,6 @@ func mustOpen(f string) *os.File {
 
 // CreateImage - Creates image on v using nanos images
 func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
-
 	var err error
 
 	config := ctx.Config()
@@ -90,7 +89,6 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	err = w.WriteField("content", "import")
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -98,13 +96,11 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	fw, err = w.CreateFormFile(fieldName, file.Name()+".raw")
 	if err != nil {
-		fmt.Printf("Error creating writer: %v\n", err)
 		return err
 	}
 
 	_, err = io.Copy(fw, file)
 	if err != nil {
-		fmt.Printf("Error with io.Copy: %v\n", err)
 		return err
 	}
 
@@ -112,7 +108,6 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/storage/"+p.isoStorageName+"/upload", &b)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -126,29 +121,17 @@ func (p *ProxMox) CreateImage(ctx *lepton.Context, imagePath string) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-
-	fmt.Println(string(body))
 
 	err = p.CheckResultType(body, "createimage", p.isoStorageName)
-	if err != nil {
-		return err
-	}
-
-	debug := false
-	if debug {
-		fmt.Println(string(body))
-	}
-
-	return nil
+	return err
 }
 
 // GetImages return all images on ProxMox

--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -339,7 +339,7 @@ type TicketData struct {
 // good for subsequent requests over 2? hrs
 // you have to use this if you use absolue paths when setting disk
 // perhaps there is a better work-around for that.
-func (p *Proxmox) getTicket() Ticket {
+func (p *ProxMox) getTicket() Ticket {
 	puser := os.Getenv("PROXMOX_USER")
 	pass := os.Getenv("PROXMOX_PASS")
 
@@ -351,7 +351,7 @@ func (p *Proxmox) getTicket() Ticket {
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/access/ticket", data)
 	if err != nil {
 		fmt.Println(err)
-		return err
+		//		return err
 	}
 
 	tr := &http.Transport{
@@ -359,6 +359,26 @@ func (p *Proxmox) getTicket() Ticket {
 	}
 	client := &http.Client{Transport: tr}
 
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err)
+		//		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		//		return err
+	}
+
+	t := Ticket{}
+
+	err = json.Unmarshal([]byte(body), &t)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return t
 }
 
 func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {

--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -24,10 +24,10 @@ type NextIDResponse struct {
 	Data string `json:"data"`
 }
 
-func (p *ProxMox) getNextID() string {
+func (p *ProxMox) getNextID() (string, error) {
 	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/cluster/nextid", nil)
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	tr := &http.Transport{
@@ -38,23 +38,22 @@ func (p *ProxMox) getNextID() string {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
+		return "", err
 	}
 
 	err = p.CheckResultType(body, "getnextid", "")
 	if err != nil {
-		return ""
+		return "", err
 	}
 
 	ir := &NextIDResponse{}
-	json.Unmarshal([]byte(body), ir)
-
-	return ir.Data
+	err = json.Unmarshal([]byte(body), ir)
+	return ir.Data, nil
 }
 
 // CreateInstance - Creates instance on Proxmox.
@@ -64,7 +63,10 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 
 	config := ctx.Config()
 
-	nextid := p.getNextID()
+	nextid, err := p.getNextID()
+	if err != nil {
+		return err
+	}
 
 	p.instanceName = config.RunConfig.InstanceName
 
@@ -114,8 +116,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		p.numa = config.TargetConfig["Numa"]
 	}
 
-	// Memory
-
 	p.memory = "512"
 	if config.TargetConfig["Memory"] != "" {
 		memoryInt, err := lepton.RAMInBytes(config.TargetConfig["Memory"])
@@ -126,28 +126,20 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		p.memory = strconv.FormatInt(memoryInt, 10)
 	}
 
-	// Main storage
-
 	p.storageName = "local-lvm"
 	if config.TargetConfig["StorageName"] != "" {
 		p.storageName = config.TargetConfig["StorageName"]
 	}
-
-	// Iso storage
 
 	p.isoStorageName = "local"
 	if config.TargetConfig["IsoStorageName"] != "" {
 		p.isoStorageName = config.TargetConfig["IsoStorageName"]
 	}
 
-	// Bridge prefix
-
 	p.bridgePrefix = "vmbr"
 	if config.TargetConfig["BridgePrefix"] != "" {
 		p.bridgePrefix = config.TargetConfig["BridgePrefix"]
 	}
-
-	// Onboot
 
 	p.onboot = "0"
 	if config.TargetConfig["Onboot"] != "" {
@@ -156,8 +148,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		}
 		p.onboot = config.TargetConfig["Onboot"]
 	}
-
-	// Protection
 
 	p.protection = "0"
 	if config.TargetConfig["Protection"] != "" {
@@ -242,8 +232,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	}
 	client := &http.Client{Transport: tr}
 
-	fmt.Printf("%s %s\n", p.tokenID, p.secret)
-
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -253,11 +241,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
-	}
-
-	debug := true // false
-	if debug {
-		fmt.Println(string(body))
 	}
 
 	err = p.CheckResultType(body, "createinstance", "file="+p.isoStorageName+":iso/"+p.imageName+".iso")
@@ -270,18 +253,15 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 
-	err = p.movDisk(ctx, nextid)
-
 	return err
 }
 
 func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
-
 	data := url.Values{}
 	data.Set("disk", "virtio0")
 	data.Set("node", p.nodeNAME)
 	data.Set("format", "raw")
-	data.Set("storage", p.storageName)
+	data.Set("storage", p.isoStorageName)
 	data.Set("vmid", vmid)
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/move_disk", bytes.NewBufferString(data.Encode()))
@@ -308,10 +288,12 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
 	return p.CheckResultType(body, "movdisk", p.storageName)
 }
 
+// Ticket is proxmox auth ticket.
 type Ticket struct {
 	Data TicketData `json:"data"`
 }
 
+// TicketData contains data for proxmox authn.
 type TicketData struct {
 	Ticket string `json:"ticket"`
 	CSRF   string `json:"CSRFPreventionToken"`
@@ -324,11 +306,17 @@ func (p *ProxMox) getTicket() (Ticket, error) {
 	puser := os.Getenv("PROXMOX_USER")
 	pass := os.Getenv("PROXMOX_PASS")
 
+	t := Ticket{}
+
+	if puser == "" || pass == "" {
+		return t, errors.New("instance creation currently requires both PROXMOX_USER and PROXMOX_PASS to be set to root user or equivalent")
+	}
+
 	var data = strings.NewReader(`username=` + puser + "&password=" + pass)
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/access/ticket", data)
 	if err != nil {
-		return err
+		return t, err
 	}
 
 	tr := &http.Transport{
@@ -338,17 +326,19 @@ func (p *ProxMox) getTicket() (Ticket, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return t, err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return t, err
 	}
 
-	t := Ticket{}
-
 	err = json.Unmarshal([]byte(body), &t)
+
+	if t.Data.CSRF == "" || t.Data.Ticket == "" {
+		return t, errors.New("empty ticket")
+	}
 
 	return t, err
 }
@@ -361,11 +351,10 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 
 	data := url.Values{}
 
-	data.Set("virtio0", "local:0,import-from=/var/lib/vz/import/server.raw")
+	data.Set("virtio0", "local:0,import-from=/var/lib/vz/import/"+p.imageName+".raw")
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -374,31 +363,25 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 	}
 	client := &http.Client{Transport: tr}
 
-	//if auth'ing w/out token: (for instance using direct path...)
 	req.Header.Add("CSRFPreventionToken", ticket.Data.CSRF)
 	clientCookie := &http.Cookie{
 		Name:  "PVEAuthCookie",
-		Value: ticket.Data.CSRF,
+		Value: ticket.Data.Ticket,
 	}
 	req.AddCookie(clientCookie)
 
-	// if we can get rid of the abs. path we can prob. drop tkt auth
-	//	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
-
-	fmt.Println(resp.StatusCode)
-
-	fmt.Println(string(body))
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("can't add disk %s", string(body))
+	}
 
 	err = p.CheckResultType(body, "addvirtiodisk", p.isoStorageName)
 	if err != nil {
@@ -416,11 +399,10 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 	req.Header.Add("CSRFPreventionToken", ticket.Data.CSRF)
 	clientCookie = &http.Cookie{
 		Name:  "PVEAuthCookie",
-		Value: ticket.Data.CSRF,
+		Value: ticket.Data.Ticket,
 	}
 	req.AddCookie(clientCookie)
 
-	//	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err = client.Do(req)
 	if err != nil {
 		return err
@@ -429,6 +411,9 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("can't add disk %s", string(body))
 	}
 
 	return p.CheckResultType(body, "bootorderset", "")
@@ -514,7 +499,6 @@ func (p *ProxMox) DeleteInstance(ctx *lepton.Context, instanceID string) error {
 
 	req, err := http.NewRequest("DELETE", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID, nil)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -544,7 +528,6 @@ func (p *ProxMox) StartInstance(ctx *lepton.Context, instanceID string) error {
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID+"/status/start", nil)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -556,13 +539,11 @@ func (p *ProxMox) StartInstance(ctx *lepton.Context, instanceID string) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -574,7 +555,6 @@ func (p *ProxMox) StopInstance(ctx *lepton.Context, instanceID string) error {
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+instanceID+"/status/stop", nil)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -586,13 +566,11 @@ func (p *ProxMox) StopInstance(ctx *lepton.Context, instanceID string) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	_, err = io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 

--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -234,7 +234,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu", bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -248,13 +247,11 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -273,7 +270,6 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 
-	// we get up to here.. but virti0 is never actually made..
 	err = p.movDisk(ctx, nextid)
 
 	return err
@@ -290,7 +286,6 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/move_disk", bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -302,29 +297,15 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
-	fmt.Println(string(body))
-
-	err = p.CheckResultType(body, "movdisk", p.storageName)
-	if err != nil {
-		return err
-	}
-
-	debug := false
-	if debug {
-		fmt.Println(string(body))
-	}
-
-	return nil
+	return p.CheckResultType(body, "movdisk", p.storageName)
 }
 
 type Ticket struct {
@@ -339,19 +320,15 @@ type TicketData struct {
 // good for subsequent requests over 2? hrs
 // you have to use this if you use absolue paths when setting disk
 // perhaps there is a better work-around for that.
-func (p *ProxMox) getTicket() Ticket {
+func (p *ProxMox) getTicket() (Ticket, error) {
 	puser := os.Getenv("PROXMOX_USER")
 	pass := os.Getenv("PROXMOX_PASS")
-
-	//curl -k -d "username=user" --data-urlencode "password=password" \
-	//https://192.168.64.2:8006/api2/json/access/ticket
 
 	var data = strings.NewReader(`username=` + puser + "&password=" + pass)
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/access/ticket", data)
 	if err != nil {
-		fmt.Println(err)
-		//		return err
+		return err
 	}
 
 	tr := &http.Transport{
@@ -361,38 +338,29 @@ func (p *ProxMox) getTicket() Ticket {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		//		return err
+		return err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
-		//		return err
+		return err
 	}
 
 	t := Ticket{}
 
 	err = json.Unmarshal([]byte(body), &t)
-	if err != nil {
-		fmt.Println(err)
-	}
 
-	return t
+	return t, err
 }
 
 func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
-	ticket := p.getTicket()
+	ticket, err := p.getTicket()
+	if err != nil {
+		return err
+	}
 
 	data := url.Values{}
 
-	// need to upload our disk ..
-
-	// local to server ; server being disk name
-	fmt.Printf("attaching %s to %s\n", p.isoStorageName, p.imageName)
-
-	// attach disk
-	//	data.Set("virtio0", "file="+p.isoStorageName+":/"+p.imageName+".raw")
 	data.Set("virtio0", "local:0,import-from=/var/lib/vz/import/server.raw")
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
@@ -442,7 +410,6 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 
 	req, err = http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -456,29 +423,15 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 	//	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err = client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
-	fmt.Println(string(body))
-
-	err = p.CheckResultType(body, "bootorderset", "")
-	if err != nil {
-		return err
-	}
-
-	debug := false
-	if debug {
-		fmt.Println(string(body))
-	}
-
-	return nil
+	return p.CheckResultType(body, "bootorderset", "")
 }
 
 // GetInstanceByName returns instance with given name
@@ -509,7 +462,6 @@ func (p *ProxMox) ListInstances(ctx *lepton.Context) error {
 
 	req, err := http.NewRequest("GET", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu", nil)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -521,13 +473,11 @@ func (p *ProxMox) ListInstances(ctx *lepton.Context) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 
@@ -576,17 +526,10 @@ func (p *ProxMox) DeleteInstance(ctx *lepton.Context, instanceID string) error {
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	defer resp.Body.Close()
 	_, err = io.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Println(err)
-		return err
-
-	}
-
 	return err
 
 }

--- a/provider/proxmox/proxmox_instance.go
+++ b/provider/proxmox/proxmox_instance.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/nanovms/ops/lepton"
 	"github.com/olekukonko/tablewriter"
@@ -242,6 +243,8 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 	}
 	client := &http.Client{Transport: tr}
 
+	fmt.Printf("%s %s\n", p.tokenID, p.secret)
+
 	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -255,7 +258,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 
-	debug := false
+	debug := true // false
 	if debug {
 		fmt.Println(string(body))
 	}
@@ -270,6 +273,7 @@ func (p *ProxMox) CreateInstance(ctx *lepton.Context) error {
 		return err
 	}
 
+	// we get up to here.. but virti0 is never actually made..
 	err = p.movDisk(ctx, nextid)
 
 	return err
@@ -308,6 +312,8 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
 		return err
 	}
 
+	fmt.Println(string(body))
+
 	err = p.CheckResultType(body, "movdisk", p.storageName)
 	if err != nil {
 		return err
@@ -321,12 +327,53 @@ func (p *ProxMox) movDisk(ctx *lepton.Context, vmid string) error {
 	return nil
 }
 
+type Ticket struct {
+	Data TicketData `json:"data"`
+}
+
+type TicketData struct {
+	Ticket string `json:"ticket"`
+	CSRF   string `json:"CSRFPreventionToken"`
+}
+
+// good for subsequent requests over 2? hrs
+// you have to use this if you use absolue paths when setting disk
+// perhaps there is a better work-around for that.
+func (p *Proxmox) getTicket() Ticket {
+	puser := os.Getenv("PROXMOX_USER")
+	pass := os.Getenv("PROXMOX_PASS")
+
+	//curl -k -d "username=user" --data-urlencode "password=password" \
+	//https://192.168.64.2:8006/api2/json/access/ticket
+
+	var data = strings.NewReader(`username=` + puser + "&password=" + pass)
+
+	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/access/ticket", data)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+}
+
 func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
+	ticket := p.getTicket()
 
 	data := url.Values{}
 
+	// need to upload our disk ..
+
+	// local to server ; server being disk name
+	fmt.Printf("attaching %s to %s\n", p.isoStorageName, p.imageName)
+
 	// attach disk
-	data.Set("virtio0", "file="+p.isoStorageName+":iso/"+p.imageName+".iso")
+	//	data.Set("virtio0", "file="+p.isoStorageName+":/"+p.imageName+".raw")
+	data.Set("virtio0", "local:0,import-from=/var/lib/vz/import/server.raw")
 
 	req, err := http.NewRequest("POST", p.apiURL+"/api2/json/nodes/"+p.nodeNAME+"/qemu/"+vmid+"/config", bytes.NewBufferString(data.Encode()))
 	if err != nil {
@@ -339,7 +386,16 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 	}
 	client := &http.Client{Transport: tr}
 
-	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
+	//if auth'ing w/out token: (for instance using direct path...)
+	req.Header.Add("CSRFPreventionToken", ticket.Data.CSRF)
+	clientCookie := &http.Cookie{
+		Name:  "PVEAuthCookie",
+		Value: ticket.Data.CSRF,
+	}
+	req.AddCookie(clientCookie)
+
+	// if we can get rid of the abs. path we can prob. drop tkt auth
+	//	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println(err)
@@ -351,6 +407,10 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 		fmt.Println(err)
 		return err
 	}
+
+	fmt.Println(resp.StatusCode)
+
+	fmt.Println(string(body))
 
 	err = p.CheckResultType(body, "addvirtiodisk", p.isoStorageName)
 	if err != nil {
@@ -366,7 +426,14 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 		return err
 	}
 
-	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
+	req.Header.Add("CSRFPreventionToken", ticket.Data.CSRF)
+	clientCookie = &http.Cookie{
+		Name:  "PVEAuthCookie",
+		Value: ticket.Data.CSRF,
+	}
+	req.AddCookie(clientCookie)
+
+	//	req.Header.Add("Authorization", "PVEAPIToken="+p.tokenID+"="+p.secret)
 	resp, err = client.Do(req)
 	if err != nil {
 		fmt.Println(err)
@@ -378,6 +445,8 @@ func (p *ProxMox) addVirtioDisk(ctx *lepton.Context, vmid string) error {
 		fmt.Println(err)
 		return err
 	}
+
+	fmt.Println(string(body))
 
 	err = p.CheckResultType(body, "bootorderset", "")
 	if err != nil {


### PR DESCRIPTION
the old proxmox instance create relied on a hack; since then one can use import-from, however that appears to require tkt based auth vs api token