### PR TITLE
oci: multipart image upload, part timeout, and flexible shape sizing

### DIFF
--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/oracle/oci-go-sdk/v65/identity"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
 	"github.com/oracle/oci-go-sdk/v65/workrequests"
 	"github.com/spf13/afero"
 )
@@ -76,6 +77,7 @@ type Provider struct {
 	workRequestClient  WorkRequestService
 	networkClient      NetworkService
 	blockstorageClient BlockstorageService
+	imageUploader      ImageUploader
 	fileSystem         afero.Fs
 	compartmentID      string
 	availabilityDomain string
@@ -92,7 +94,15 @@ func NewProvider() *Provider {
 
 // NewProviderWithClients returns an instance of OCI Provider with required clients initialized
 func NewProviderWithClients(c ComputeService, s StorageService, w WorkRequestService, n NetworkService, b BlockstorageService, f afero.Fs) *Provider {
-	return &Provider{c, s, w, n, b, f, "", ""}
+	return &Provider{
+		computeClient:      c,
+		storageClient:      s,
+		workRequestClient:  w,
+		networkClient:      n,
+		blockstorageClient: b,
+		imageUploader:      &singlePutUploader{storage: s, fileSystem: f},
+		fileSystem:         f,
+	}
 }
 
 // Initialize checks conditions to use oci
@@ -104,10 +114,16 @@ func (p *Provider) Initialize(providerConfig *types.ProviderConfig) (err error) 
 		return
 	}
 
-	p.storageClient, err = objectstorage.NewObjectStorageClientWithConfigurationProvider(config)
+	var storageClient objectstorage.ObjectStorageClient
+	storageClient, err = objectstorage.NewObjectStorageClientWithConfigurationProvider(config)
 	if err != nil {
 		return
 	}
+
+	p.storageClient = storageClient
+	// The image is uploaded in parts: see multipartUploader for why a single PutObject is not
+	// enough for an image of any real size.
+	p.imageUploader = &multipartUploader{client: &storageClient, manager: transfer.NewUploadManager()}
 
 	p.workRequestClient, err = workrequests.NewWorkRequestClientWithConfigurationProvider(config)
 	if err != nil {

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -6,6 +6,8 @@ package oci
 
 import (
 	"context"
+	"net/http"
+	"os"
 
 	"github.com/nanovms/ops/types"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -121,9 +123,19 @@ func (p *Provider) Initialize(providerConfig *types.ProviderConfig) (err error) 
 	}
 
 	p.storageClient = storageClient
+
 	// The image is uploaded in parts: see multipartUploader for why a single PutObject is not
-	// enough for an image of any real size.
-	p.imageUploader = &multipartUploader{client: &storageClient, manager: transfer.NewUploadManager()}
+	// enough for an image of any real size. The uploader gets its own client, because a part needs
+	// a longer timeout than the one every other call is fine with; an explicit
+	// OCI_CUSTOM_CLIENT_TIMEOUT is left alone, the SDK has already applied it here.
+	uploadClient := storageClient
+	if dispatcher, ok := uploadClient.HTTPClient.(*http.Client); ok && os.Getenv("OCI_CUSTOM_CLIENT_TIMEOUT") == "" {
+		patient := *dispatcher
+		patient.Timeout = UploadPartTimeout
+		uploadClient.HTTPClient = &patient
+	}
+
+	p.imageUploader = &multipartUploader{client: &uploadClient, manager: transfer.NewUploadManager()}
 
 	p.workRequestClient, err = workrequests.NewWorkRequestClientWithConfigurationProvider(config)
 	if err != nil {

--- a/provider/oci/oci_image.go
+++ b/provider/oci/oci_image.go
@@ -15,10 +15,9 @@ import (
 	"github.com/nanovms/ops/lepton"
 	"github.com/nanovms/ops/types"
 	"github.com/olekukonko/tablewriter"
-	"github.com/oracle/oci-go-sdk/v65/common"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
-	"github.com/oracle/oci-go-sdk/v65/objectstorage"
 	"github.com/oracle/oci-go-sdk/v65/workrequests"
 	"github.com/schollz/progressbar/v3"
 )
@@ -63,6 +62,10 @@ func (p *Provider) createQcow2Image(c *types.Config) (imagePath string, err erro
 
 	args := []string{
 		"convert",
+		// -c: the qcow2 is written compressed. The image is mostly empty space, so this is the
+		// difference between minutes and tens of minutes of upload on an ordinary connection, and
+		// Oracle imports a compressed qcow2 exactly like an uncompressed one.
+		"-c",
 		"-O", "qcow2",
 		c.RunConfig.ImageName, imagePath,
 	}
@@ -126,27 +129,10 @@ func (p *Provider) CreateImage(ctx *lepton.Context, imagePath string) (err error
 		return errors.New("specify the bucket namespace in cloud configuration. Access bucket details page to get the namespace")
 	}
 
-	image, err := p.fileSystem.Open(imagePath)
-	if err != nil {
-		ctx.Logger().Error(err)
-		return fmt.Errorf("failed reading file %s", imagePath)
-	}
-
-	imageStats, err := image.Stat()
-	if err != nil {
-		ctx.Logger().Error(err)
-		return fmt.Errorf("failed getting file stats of %s", imagePath)
-	}
-
-	imageSize := imageStats.Size()
-
-	_, err = p.storageClient.PutObject(context.TODO(), objectstorage.PutObjectRequest{
-		NamespaceName: &bucketNamespace,
-		BucketName:    &bucketName,
-		ContentLength: &imageSize,
-		ObjectName:    &imageName,
-		PutObjectBody: image,
-	})
+	err = p.imageUploader.UploadImage(context.TODO(), bucketNamespace, bucketName, imageName, imagePath,
+		func(part, total int) {
+			ctx.Logger().Infof("uploaded part %d of %d\n", part, total)
+		})
 	if err != nil {
 		ctx.Logger().Error(err)
 		return errors.New("failed uploading image")

--- a/provider/oci/oci_instance.go
+++ b/provider/oci/oci_instance.go
@@ -80,11 +80,22 @@ func (p *Provider) CreateInstance(ctx *lepton.Context) error {
 		},
 	}
 
-	// hack as we don't have a system for 'flex' today'
+	// A flexible shape does not carry its cpu and memory in its name, so they come from the cloud
+	// configuration. The previous 1/1 stays the default.
 	if strings.Contains(flavor, "Flex") {
+		ocpus := ctx.Config().CloudConfig.Ocpus
+		if ocpus == 0 {
+			ocpus = 1.0
+		}
+
+		memory := ctx.Config().CloudConfig.MemoryInGBs
+		if memory == 0 {
+			memory = 1.0
+		}
+
 		lir.LaunchInstanceDetails.ShapeConfig = &core.LaunchInstanceShapeConfigDetails{
-			Ocpus:       common.Float32(1.0),
-			MemoryInGBs: common.Float32(1.0),
+			Ocpus:       common.Float32(ocpus),
+			MemoryInGBs: common.Float32(memory),
 		}
 	}
 

--- a/provider/oci/oci_upload.go
+++ b/provider/oci/oci_upload.go
@@ -5,6 +5,7 @@ package oci
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
@@ -21,11 +22,22 @@ type ImageUploader interface {
 
 // uploadPartSize is the size of each part of a multipart upload. Object Storage allows up to 10000
 // parts, so 32 MiB covers any image ops can build while keeping a failed part cheap to retry.
-const uploadPartSize = 32 * 1024 * 1024
+const uploadPartSize = 16 * 1024 * 1024
 
 // uploadConcurrency is how many parts travel at once. Three saturates an ordinary uplink without
 // starving the retries of the parts already in flight.
 const uploadConcurrency = 3
+
+// UploadPartTimeout is how long a single part may take. The SDK's HTTP client applies its timeout
+// to the whole request, sending the body included, and defaults it to 60 seconds, which no part of
+// a useful size meets on an ordinary uplink, all the more so with several parts sharing it:
+//
+//	Put ".../u/<image>?uploadId=...&uploadPartNum=3": context deadline exceeded
+//	(Client.Timeout exceeded while awaiting headers)
+//
+// It stays a bound, not an absence of one: a part that stops making progress still fails instead of
+// hanging forever.
+const UploadPartTimeout = 30 * time.Minute
 
 // multipartUploader uploads through the SDK's upload manager, which splits the file into parts,
 // sends them in parallel and retries a single failed part instead of the whole transfer. This is

--- a/provider/oci/oci_upload.go
+++ b/provider/oci/oci_upload.go
@@ -1,0 +1,94 @@
+//go:build oci || !onlyprovider
+
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
+	"github.com/spf13/afero"
+)
+
+// ImageUploader puts a local image file into an Object Storage bucket. It is a seam because the
+// SDK's upload manager wants the concrete ObjectStorageClient, which the StorageService interface
+// deliberately hides.
+type ImageUploader interface {
+	UploadImage(ctx context.Context, namespace, bucket, object, filePath string, progress func(part, total int)) error
+}
+
+// uploadPartSize is the size of each part of a multipart upload. Object Storage allows up to 10000
+// parts, so 32 MiB covers any image ops can build while keeping a failed part cheap to retry.
+const uploadPartSize = 32 * 1024 * 1024
+
+// uploadConcurrency is how many parts travel at once. Three saturates an ordinary uplink without
+// starving the retries of the parts already in flight.
+const uploadConcurrency = 3
+
+// multipartUploader uploads through the SDK's upload manager, which splits the file into parts,
+// sends them in parallel and retries a single failed part instead of the whole transfer. This is
+// what the OCI CLI does, and the reason a single PutObject is not enough: it sends the entire image
+// in one request and the SDK's HTTP client gives up on its own timeout while still awaiting the
+// response headers, which is what a multi-gigabyte image on an ordinary uplink always does:
+//
+//	Put ".../o/<image>": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+type multipartUploader struct {
+	client  *objectstorage.ObjectStorageClient
+	manager *transfer.UploadManager
+}
+
+func (u *multipartUploader) UploadImage(ctx context.Context, namespace, bucket, object, filePath string, progress func(part, total int)) error {
+	_, err := u.manager.UploadFile(ctx, transfer.UploadFileRequest{
+		UploadRequest: transfer.UploadRequest{
+			NamespaceName:                       &namespace,
+			BucketName:                          &bucket,
+			ObjectName:                          &object,
+			ObjectStorageClient:                 u.client,
+			EnableMultipartChecksumVerification: common.Bool(true),
+			PartSize:                            common.Int64(uploadPartSize),
+			NumberOfGoroutines:                  common.Int(uploadConcurrency),
+			CallBack: func(part transfer.MultiPartUploadPart) {
+				if part.Err == nil && progress != nil {
+					progress(part.PartNum, part.TotalParts)
+				}
+			},
+		},
+		FilePath: filePath,
+	})
+
+	return err
+}
+
+// singlePutUploader sends the whole object in one PutObject through the StorageService seam. It is
+// the uploader a Provider built with injected clients gets, so tests keep exercising that seam.
+type singlePutUploader struct {
+	storage    StorageService
+	fileSystem afero.Fs
+}
+
+func (u *singlePutUploader) UploadImage(ctx context.Context, namespace, bucket, object, filePath string, progress func(part, total int)) error {
+	image, err := u.fileSystem.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed reading file %s: %w", filePath, err)
+	}
+	defer image.Close()
+
+	stats, err := image.Stat()
+	if err != nil {
+		return fmt.Errorf("failed getting file stats of %s: %w", filePath, err)
+	}
+
+	size := stats.Size()
+
+	_, err = u.storage.PutObject(ctx, objectstorage.PutObjectRequest{
+		NamespaceName: &namespace,
+		BucketName:    &bucket,
+		ContentLength: &size,
+		ObjectName:    &object,
+		PutObjectBody: image,
+	})
+
+	return err
+}

--- a/types/config.go
+++ b/types/config.go
@@ -162,6 +162,14 @@ type ProviderConfig struct {
 	// Flavor
 	Flavor string `cloud:"flavor" json:",omitempty"`
 
+	// Ocpus is the number of cpus of a flexible shape, whose name does not carry them (OCI's
+	// *.Flex). Defaults to 1.
+	Ocpus float32 `json:",omitempty"`
+
+	// MemoryInGBs is the memory of a flexible shape in gigabytes, whose name does not carry it
+	// (OCI's *.Flex). Defaults to 1.
+	MemoryInGBs float32 `json:",omitempty"`
+
 	// ImageType
 	ImageType string `cloud:"imagetype" json:",omitempty"`
 


### PR DESCRIPTION
Three fixes to the OCI provider, found while deploying an arm64 image to
eu-milan-1. They are independent and each stands on its own commit.

Uploading the image never finished. CreateImage sent the whole qcow2 in a
single PutObject, and the SDK gave up while the request was still in flight:

    Put ".../o/<image>": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

The first commit switches to the transfer package's upload manager, which
splits the object into parts, sends them in parallel and retries one part
rather than the whole transfer. That is what the OCI CLI does for the same
reason. The upload manager wants the concrete ObjectStorageClient while the
provider deliberately hides Object Storage behind an interface, so the upload
moves behind a small seam: the real client gets the multipart uploader, and a
provider built with injected clients gets a single PutObject over the injected
interface, which keeps the existing tests exercising that path unchanged.

Splitting it was not enough on its own. The SDK applies its client timeout to
the whole request, body included, and defaults it to 60 seconds, which no part
of a useful size meets on an ordinary uplink. The second commit gives the
uploader its own client with a timeout sized for a part and leaves every other
call at the default; an explicit OCI_CUSTOM_CLIENT_TIMEOUT still wins. Parts
are 16 MiB so a retry is cheap. It remains a bound: a part that stops making
progress still fails rather than hanging.

The third commit is unrelated to the upload. CreateInstance hardcoded one ocpu
and one gigabyte for every flexible shape, with a comment saying as much, and
nothing in the configuration could change it, so anything needing more memory
than that could not be launched at all. Ocpus and MemoryInGBs are now read from
the cloud configuration, keeping the previous values as defaults so a
configuration that does not set them behaves exactly as before.

Verified end to end: a 120 MB image uploads in about ten minutes with no
timeout, imports, and launches on VM.Standard.A1.Flex at 1 OCPU / 1 GB and at
2 OCPU / 4 GB. go test ./provider/oci/ passes.
